### PR TITLE
Azure detection + attestation report fetch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ hex = "0.4"
 x509-parser = { version="^0.14", features=["verify"] }
 asn1-rs = "*"
 rand = "*"
+tss-esapi = "7.2"

--- a/docs/snpguest.1.adoc
+++ b/docs/snpguest.1.adoc
@@ -26,13 +26,16 @@ GLOBAL OPTIONS
 COMMANDS
 --------
 *snpguest report*::
-    usage: snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random]
+    usage: snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random] [-p, --platform]
     
     Requests an attestation report from the host and writes it in a file with the provided request data and vmpl. 
     Will write the contents of the attestation report in binary format into the specified report path.
     A path for the attestation report must be provided.
     User can pass 64 bytes of data in any file format into $REQUEST_FILE in order to use that data to request the attestation report.
     The user can use the --random flag to generate and use random data for request data.
+    For Microsoft Hyper-V guests, a user can use the --platform flag to use the request data that was pre-generated
+    from the platform. Currently, for Hyper-V guests, --platform is required, as there is no ability to write
+    request data for the attestation report.
     If the user uses the --random flag, then the data will be written into the file they provided in $REQUEST_FILE.
     VMPL is an optional parameter and it defaults to 1.
     

--- a/src/display.rs
+++ b/src/display.rs
@@ -19,15 +19,14 @@ mod report_display {
 
     #[derive(StructOpt)]
     pub struct Args {
-        #[structopt(
-            help = "Path to attestation report to display."
-        )]
+        #[structopt(help = "Path to attestation report to display.")]
         pub att_report_path: PathBuf,
     }
 
     // Print attestation report in console
     pub fn display_attestation_report(args: Args, quiet: bool) -> Result<()> {
-        let att_report = report::read_report(args.att_report_path).context("Could not open attestation report")?;
+        let att_report = report::read_report(args.att_report_path)
+            .context("Could not open attestation report")?;
 
         if !quiet {
             println!("{}", att_report);

--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -68,7 +68,7 @@ pub fn present() -> bool {
 pub mod report {
     use super::*;
 
-    use anyhow::Context;
+    use anyhow::{anyhow, Context};
     use serde::{Deserialize, Serialize};
     use sev::firmware::guest::AttestationReport;
     use tss_esapi::{
@@ -88,7 +88,10 @@ pub mod report {
         rsv2: [u32; 5],
     }
 
-    pub fn get() -> Result<AttestationReport> {
+    pub fn get(vmpl: u32) -> Result<AttestationReport> {
+        if vmpl > 0 {
+            return Err(anyhow!("Azure vTPM attestation report requires VMPL 0"));
+        }
         let bytes = tpm2_read().context("unable to read attestation report bytes from vTPM")?;
 
         hcl_report(&bytes)

--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -21,17 +21,17 @@ const CPUID_HYPERV_ISOLATION_TYPE_MASK: u32 = 0xf;
 const CPUID_HYPERV_ISOLATION_TYPE_SNP: u32 = 2;
 
 pub fn present() -> bool {
-    let cpuid = unsafe { __cpuid(CPUID_PROCESSOR_INFO_AND_FEATURE_BITS) };
+    let mut cpuid = unsafe { __cpuid(CPUID_PROCESSOR_INFO_AND_FEATURE_BITS) };
     if (cpuid.ecx & CPUID_FEATURE_HYPERVISOR) == 0 {
         return false;
     }
 
-    let cpuid = unsafe { __cpuid(CPUID_GET_HIGHEST_FUNCTION) };
+    cpuid = unsafe { __cpuid(CPUID_GET_HIGHEST_FUNCTION) };
     if cpuid.eax < CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS {
         return false;
     }
 
-    let cpuid = unsafe { __cpuid(CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS) };
+    cpuid = unsafe { __cpuid(CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS) };
     if cpuid.eax < CPUID_HYPERV_MIN || cpuid.eax > CPUID_HYPERV_MAX {
         return false;
     }
@@ -45,7 +45,7 @@ pub fn present() -> bool {
         return false;
     }
 
-    let cpuid = unsafe { __cpuid(CPUID_HYPERV_FEATURES) };
+    cpuid = unsafe { __cpuid(CPUID_HYPERV_FEATURES) };
 
     let isolated: bool = (cpuid.ebx & CPUID_HYPERV_ISOLATION) != 0;
     let managed: bool = (cpuid.ebx & CPUID_HYPERV_CPU_MANAGEMENT) != 0;
@@ -54,7 +54,7 @@ pub fn present() -> bool {
         return false;
     }
 
-    let cpuid = unsafe { __cpuid(CPUID_HYPERV_ISOLATION_CONFIG) };
+    cpuid = unsafe { __cpuid(CPUID_HYPERV_ISOLATION_CONFIG) };
     let mask = cpuid.ebx & CPUID_HYPERV_ISOLATION_TYPE_MASK;
     let snp = CPUID_HYPERV_ISOLATION_TYPE_SNP;
 

--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -4,6 +4,11 @@ use super::*;
 
 use std::arch::x86_64::__cpuid;
 
+const CPUID_GET_HIGHEST_FUNCTION: u32 = 0x80000000;
+const CPUID_PROCESSOR_INFO_AND_FEATURE_BITS: u32 = 0x1;
+
+const CPUID_FEATURE_HYPERVISOR: u32 = 1 << 31;
+
 const CPUID_HYPERV_SIG: &str = "Microsoft Hv";
 const CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS: u32 = 0x40000000;
 const CPUID_HYPERV_FEATURES: u32 = 0x40000003;
@@ -16,6 +21,16 @@ const CPUID_HYPERV_ISOLATION_TYPE_MASK: u32 = 0xf;
 const CPUID_HYPERV_ISOLATION_TYPE_SNP: u32 = 2;
 
 pub fn present() -> bool {
+    let cpuid = unsafe { __cpuid(CPUID_PROCESSOR_INFO_AND_FEATURE_BITS) };
+    if (cpuid.ecx & CPUID_FEATURE_HYPERVISOR) == 0 {
+        return false;
+    }
+
+    let cpuid = unsafe { __cpuid(CPUID_GET_HIGHEST_FUNCTION) };
+    if cpuid.eax < CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS {
+        return false;
+    }
+
     let cpuid = unsafe { __cpuid(CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS) };
     if cpuid.eax < CPUID_HYPERV_MIN || cpuid.eax > CPUID_HYPERV_MAX {
         return false;

--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::arch::x86_64::__cpuid;
+
+const CPUID_HYPERV_SIG: &str = "Microsoft Hv";
+const CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS: u32 = 0x40000000;
+const CPUID_HYPERV_FEATURES: u32 = 0x40000003;
+const CPUID_HYPERV_MIN: u32 = 0x40000005;
+const CPUID_HYPERV_MAX: u32 = 0x4000ffff;
+const CPUID_HYPERV_ISOLATION: u32 = 1 << 22;
+const CPUID_HYPERV_CPU_MANAGEMENT: u32 = 1 << 12;
+const CPUID_HYPERV_ISOLATION_CONFIG: u32 = 0x4000000C;
+const CPUID_HYPERV_ISOLATION_TYPE_MASK: u32 = 0xf;
+const CPUID_HYPERV_ISOLATION_TYPE_SNP: u32 = 2;
+
+pub fn present() -> bool {
+    let cpuid = unsafe { __cpuid(CPUID_HYPERV_VENDOR_AND_MAX_FUNCTIONS) };
+    if cpuid.eax < CPUID_HYPERV_MIN || cpuid.eax > CPUID_HYPERV_MAX {
+        return false;
+    }
+
+    let mut sig: Vec<u8> = vec![];
+    sig.append(&mut cpuid.ebx.to_le_bytes().to_vec());
+    sig.append(&mut cpuid.ecx.to_le_bytes().to_vec());
+    sig.append(&mut cpuid.edx.to_le_bytes().to_vec());
+
+    if sig != CPUID_HYPERV_SIG.as_bytes() {
+        return false;
+    }
+
+    let cpuid = unsafe { __cpuid(CPUID_HYPERV_FEATURES) };
+
+    let isolated: bool = (cpuid.ebx & CPUID_HYPERV_ISOLATION) != 0;
+    let managed: bool = (cpuid.ebx & CPUID_HYPERV_CPU_MANAGEMENT) != 0;
+
+    if !isolated || managed {
+        return false;
+    }
+
+    let cpuid = unsafe { __cpuid(CPUID_HYPERV_ISOLATION_CONFIG) };
+    let mask = cpuid.ebx & CPUID_HYPERV_ISOLATION_TYPE_MASK;
+    let snp = CPUID_HYPERV_ISOLATION_TYPE_SNP;
+
+    if mask != snp {
+        return false;
+    }
+
+    true
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     let hv = hyperv::present();
 
     let status = match snpguest.cmd {
-        SnpGuestCmd::Report(args) => report::get_report(args),
+        SnpGuestCmd::Report(args) => report::get_report(args, hv),
         SnpGuestCmd::Certificates(args) => certs::get_ext_certs(args),
         SnpGuestCmd::Fetch(subcmd) => fetch::cmd(subcmd),
         SnpGuestCmd::Verify(subcmd) => verify::cmd(subcmd, snpguest.quiet),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod fetch;
 mod report;
 mod verify;
 
+mod hyperv;
+
 use certs::CertificatesArgs;
 use display::DisplayCmd;
 use fetch::FetchCmd;
@@ -51,6 +53,7 @@ fn main() -> Result<()> {
     env_logger::init();
 
     let snpguest = SnpGuest::from_args();
+    let hv = hyperv::present();
 
     let status = match snpguest.cmd {
         SnpGuestCmd::Report(args) => report::get_report(args),

--- a/src/report.rs
+++ b/src/report.rs
@@ -27,7 +27,7 @@ pub fn read_report(att_report_path: PathBuf) -> Result<AttestationReport, anyhow
 pub fn create_random_request() -> [u8; 64] {
     let mut data = [0u8; 64];
     thread_rng().fill_bytes(&mut data);
-   data
+    data
 }
 
 // Write data into given file. Split it into 16 byte lines.
@@ -79,29 +79,29 @@ pub fn get_report(args: ReportArgs) -> Result<()> {
         true => {
             let request_buf = create_random_request();
 
-                // Overwrite data if file already exists
-                let request_file = if args.request_file.exists() {
-                    std::fs::OpenOptions::new()
-                        .write(true)
-                        .truncate(true)
-                        .open(args.request_file)
-                        .context("Unable to overwrite request file contents")?
-                } else {
-                    fs::File::create(args.request_file).context("Unable to create request file.")?
-                };
-                write_hex(&mut BufWriter::new(request_file), &request_buf)
-                    .context("Failed to write request data in request file")?;
-                request_buf
-        },
+            // Overwrite data if file already exists
+            let request_file = if args.request_file.exists() {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(args.request_file)
+                    .context("Unable to overwrite request file contents")?
+            } else {
+                fs::File::create(args.request_file).context("Unable to create request file.")?
+            };
+            write_hex(&mut BufWriter::new(request_file), &request_buf)
+                .context("Failed to write request data in request file")?;
+            request_buf
+        }
         false => {
             let mut request_file =
-                    File::open(args.request_file).context("Could not open the report request file.")?;
-                let mut request_buf: [u8; 64] = [0; 64];
-                request_file
-                    .read(&mut request_buf)
-                    .context("Could not read report request file.")?;
-                request_buf
-        }   
+                File::open(args.request_file).context("Could not open the report request file.")?;
+            let mut request_buf: [u8; 64] = [0; 64];
+            request_file
+                .read(&mut request_buf)
+                .context("Could not read report request file.")?;
+            request_buf
+        }
     };
 
     // Get attestation report

--- a/src/report.rs
+++ b/src/report.rs
@@ -104,7 +104,7 @@ pub fn get_report(args: ReportArgs, hv: bool) -> Result<()> {
 
     // Get attestation report
     let att_report = if hv {
-        hyperv::report::get()?
+        hyperv::report::get(args.vmpl.unwrap_or(0))?
     } else {
         let mut sev_fw: Firmware =
             Firmware::open().context("failed to open SEV firmware device.")?;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -51,7 +51,7 @@ mod certificate_chain {
     pub fn validate_cc(args: Args, quiet: bool) -> Result<()> {
         let ark_path = find_cert_in_dir(args.certs_dir.clone(), "ark")?;
         let ask_path = find_cert_in_dir(args.certs_dir.clone(), "ask")?;
-        let vcek_path = find_cert_in_dir(args.certs_dir.clone(), "vcek")?;
+        let vcek_path = find_cert_in_dir(args.certs_dir, "vcek")?;
 
         // Get a cert chain from directory
         let cert_chain: Chain = CertPaths {


### PR DESCRIPTION
This PR introduces two new features:
1. Detecting if snpguest is running inside of a Azure CVM
2. If so, fetching the attestation report from the vTPM, rather than the /dev/sev-guest device