### PR TITLE
VCEK: Patching for x509 error

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -223,7 +223,19 @@ mod attestation {
 
     // Check cert extension bytes to data
     fn check_cert_ext_bytes(ext: &X509Extension, val: &[u8]) -> bool {
-        ext.value == val
+        // Patching for a bug found in the VCEK where the raw bytes
+        // were provided instead of a DER encoded Octet String. Now
+        // this function will handle both.
+        if ext.value.len() > 0x40 {
+            if ext.value[0] != 0x4 {
+                panic!("Invalid type encountered!");
+            } else if ext.value[1] != 0x40 {
+                panic!("Invalid octet length encountered");
+            }
+            &ext.value[2..] == val
+        } else {
+            ext.value == val
+        }
     }
 
     fn verify_attestation_tcb(


### PR DESCRIPTION
The AMD KDS was providing a malformed x509 certificate where a few of the custom extension values were raw bytes instead of DER encoded Octet Strings. This patch will now add support for covering both cases. At some future time, we should be able to remove the conditional check.

Also some fixed some clippy errors.