### PR TITLE
hyperv: Adding feature flag for hyperv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ rust-version = "1.66"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+hyperv = ["tss-esapi"]
+
 [dependencies]
 structopt = "0.3"
 env_logger = "0.10.0"
@@ -28,4 +32,4 @@ hex = "0.4"
 x509-parser = { version="^0.14", features=["verify"] }
 asn1-rs = "*"
 rand = "*"
-tss-esapi = "7.2"
+tss-esapi = { version = "7.2", optional=true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@
 mod certs;
 mod display;
 mod fetch;
-mod hyperv;
 mod key;
 mod report;
 mod verify;
+
+#[cfg(feature = "hyperv")]
+mod hyperv;
 
 use certs::CertificatesArgs;
 use display::DisplayCmd;
@@ -57,7 +59,12 @@ fn main() -> Result<()> {
     env_logger::init();
 
     let snpguest = SnpGuest::from_args();
-    let hv = hyperv::present();
+
+    #[cfg(feature = "hyperv")]
+    let hv = hyperv::present;
+
+    #[cfg(not(feature = "hyperv"))]
+    let hv = false;
 
     let status = match snpguest.cmd {
         SnpGuestCmd::Report(args) => report::get_report(args, hv),


### PR DESCRIPTION
Adding a feature flag to block out HyperV
specific code blocks, imports, etc.