### PR TITLE
Fixing report request serialization

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -129,10 +129,8 @@ pub fn get_report(args: ReportArgs, hv: bool) -> Result<()> {
         .write(true)
         .open(&args.att_report_path)?;
 
-    write!(&mut file, "{}", report).context(format!(
-        "unable to write attestation report to {}",
-        args.att_report_path.display()
-    ))?;
+    bincode::serialize_into(&mut file, &report)
+        .context("Could not serialize attestation report into file.")?;
 
     /*
      * Write reports report data (only for --random or --platform).


### PR DESCRIPTION
Fixing the way the attestation report is being written into a file using serialization.

Fixes bug in issue https://github.com/virtee/snpguest/issues/25
