### PR TITLE
hyperv: Missing closure for boolean state.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
     let snpguest = SnpGuest::from_args();
 
     #[cfg(feature = "hyperv")]
-    let hv = hyperv::present;
+    let hv = hyperv::present();
 
     #[cfg(not(feature = "hyperv"))]
     let hv = false;


### PR DESCRIPTION
When attempting to build with the hyperv flag, previously the hv variable passed to report::get_report was a function pointer and not a boolean value. Changing the non-hyperv state to call the function which returns a boolean makes this work correctly