### PR TITLE
VLEK: Adding ASVK Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210c2ddcae6f3ca89e9f78449479e4e2f0d8b9ea68e4415e4d5daeb3e6fcedb8"
+checksum = "b2890179f8ef689340f441ba05f0b268bc14f672ae4b36d629cc2266d0d747ab"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "snpguest"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snpguest"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The VirTEE Project Developers"]
 edition = "2021"
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ hyperv = ["tss-esapi"]
 structopt = "0.3"
 env_logger = "0.10.0"
 anyhow = "1.0.69"
-sev = { version = "^3.0.0", default-features = false, features = ['openssl','snp']}
+sev = { version = "^3.1.1", default-features = false, features = ['openssl','snp']}
 nix = "^0.23"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "^1.2.1"


### PR DESCRIPTION
With the release of the VLEK, there is a separate api endpoint for requesting VLEK signing keys which are known as an AMD Signing VLEK Key (ASVK). This adds logic to handle these special use-cases. As the [GHCB](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56421.pdf#page=53) does not offer a unique GUID, assumptive logic must be applied to when the file should be named appropriately ASVK or ASK.