### PR TITLE
Fix the context message for failing to open SEV firmware.

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -94,7 +94,7 @@ fn request_hardware_report(
 
 #[cfg(not(feature = "hyperv"))]
 fn request_hardware_report(data: Option<[u8; 64]>, vmpl: Option<u32>) -> Result<AttestationReport> {
-    let mut fw = Firmware::open().context("unable to open /dev/sev")?;
+    let mut fw = Firmware::open().context("unable to open /dev/sev-guest")?;
     fw.get_report(None, data, vmpl)
         .context("unable to fetch attestation report")
 }


### PR DESCRIPTION
As below, SEV-SNP guest firmware device file is usually /dev/sev-guest at present. thus it'd be better if the context message contained it.

https://github.com/virtee/sev/blob/v3.1.1/src/firmware/guest/mod.rs#L66