### PR TITLE
fix: remove subcommand trait on `ok` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@ enum SnpGuestCmd {
     Key(KeyArgs),
 
     /// Probe system for SEV-SNP support.
-    #[command(subcommand)]
     Ok,
 }
 


### PR DESCRIPTION
Remove `subcommand` trait from `Ok`. This fixes the prior behaviour where the usage was printed rather than the expected functionality occurring.

With the fix:

```
$ sudo snpguest ok 
[ PASS ] - SEV: ENABLED
[ PASS ] - SEV-ES: ENABLED
[ PASS ] - SNP: ENABLED
[ PASS ] - Optional Features statuses:
[ PASS ]   - VTOM: DISABLED
[ PASS ]   - ReflectVC: DISABLED
[ PASS ]   - Restricted Injection: DISABLED
[ PASS ]   - Alternate Injection: DISABLED
[ PASS ]   - Debug Swap: DISABLED
[ PASS ]   - Prevent Host IBS: DISABLED
[ PASS ]   - SNP BTB Isolation: DISABLED
[ PASS ]   - VMPL SSS: DISABLED
[ PASS ]   - Secure TSE: DISABLED
[ PASS ]   - VMG Exit Parameter: DISABLED
[ PASS ]   - IBS Virtualization: DISABLED
[ PASS ]   - VMSA Reg Prot: DISABLED
[ PASS ]   - SMT Protection: DISABLED
```

Fixes #55 