### PR TITLE
Adding preattestation functionality to snpguest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,15 +212,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 
 [[package]]
 name = "cfg-if"
@@ -236,6 +236,15 @@ checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-num"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -660,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -897,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1055,9 +1064,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1108,6 +1120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1279,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
@@ -1306,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1317,11 +1338,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1340,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35156eab65ff1b63432b5a11a06b770e92120033e2831c7dee064865de5dbbbd"
+checksum = "a97bd0b2e2d937951add10c8512a2dacc6ad29b39e5c5f26565a3e443329857d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -1356,6 +1378,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "openssl",
+ "rdrand",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -1378,9 +1401,11 @@ version = "0.5.1"
 dependencies = [
  "anyhow",
  "asn1-rs",
+ "base64 0.22.1",
  "bincode",
  "bitfield 0.13.2",
  "clap",
+ "clap-num",
  "colorful",
  "env_logger",
  "hex",
@@ -1492,20 +1517,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1585,9 +1611,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1859,11 +1885,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1886,6 +1912,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2038,6 +2073,27 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hyperv = ["tss-esapi"]
 clap = { version = "<4.5", features = [ "derive" ] }
 env_logger = "0.10.0"
 anyhow = "1.0.69"
-sev = { version = "^3.1.1", default-features = false, features = ['openssl','snp']}
+sev = { version = "4.0", default-features = false, features = ['openssl','snp']}
 nix = "^0.23"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "^1.2.1"
@@ -36,3 +36,5 @@ tss-esapi = { version = "7.2", optional=true }
 msru = "0.2.0"
 colorful = "0.2.2"
 bitfield = "0.13.2"
+clap-num = "1.1.1"
+base64 = "0.22.1"

--- a/docs/snpguest.1.adoc
+++ b/docs/snpguest.1.adoc
@@ -131,8 +131,98 @@ COMMANDS
     -s, --guest_svn                Specify the guest SVN to mix into the key.
     -t, --tcb_version               Specify the TCB version to mix into the derived key. 
     -v, --vmpl                      Specify VMPL level the Guest is running on. Defaults to 1.
- 
 
+*snpguest generate measurement*::
+    usage: snpguest generate measurement [-v, --vcpus] [--vcpu-type] [--vcpu-sig] [--vcpu-family] [--vcpu-model] [--vcpu-stepping] [-t, --vmm-type] [-o ,--ovmf] [-k, --kernel]
+            [-i, --initrd] [-a, --append] [-g, --guest-features] [--ovmf-hash] [-f, --output-format] [-m, --measurement-file]
+    
+    Calculates a secure guest expected launch digest measurement.
+    Every parameter passed in is used to calculate this measurement, but the user does not need to provide every parameter.
+    The only mandatory parameters are the [-o, --ovmf] parameter which is a path to the ovmf file used to launch the secure guest, and provide the guest vcpu type.
+    There are 3 ways to provide the vcpu type, and the 3 of them are mutually exclusive (will get an error if the user tries to use more than one method):
+        - [--vcpu-type] A string with the vcpu-type used to launch the secure guest
+        - [--vcpu-sig] The signature of the vcpu-type used to launch the secure guest
+        - [--vcpu-family] [--vcpu-model] [--vcpu-stepping] The family, model and stepping of the vcpu used to launch the secure guest.
+            Family, model and stepping have to be used together, if they're not all provided together an error will be raised.
+    If the user provides the [-k, --kernel] parameter to calculate the measurement, they also need to provide [-i, --initrd] and [-a, --append].
+    There were kernel features added that affect the result of the measurement if those are enabled. With the [-g, --guest-features] parameter the user can provide which of this features are enabled in their kernel.
+    The [-g, --guest-features] can be a hex or decimal number that cover the features enabled. 
+    For information on the guest-features bitfield checkout: https://github.com/virtee/sev/blob/a3c91d7b6e742c1b5685a7e0c1e5464819527b06/src/measurement/vmsa.rs#L139
+    A user can use a pre-calculated ovmf-hash using [--ovmf-hash], but the ovmf file still has to be provided.
+    The calculated measurement will be printed in the console, if the user wishes to store the measurement value they can provide a file path with [-m, --measurement-file] and the measurement will get written there.
+    If the [--quiet] flag is used, nothing will be printed out.
+
+    options:
+    -h, --help  Show a help message
+    -v, --vcpus  Number of guest vcpus [default: 1]
+    --vcpu-type  Type of guest vcpu (EPYC, EPYC-v1, EPYC-v2, EPYC-IBPB, EPYC-v3, EPYC-v4, EPYC-Rome, EPYC-Rome-v1, EPYC-Rome-v2, EPYC-Rome-v3, EPYC-Milan, EPYC- Milan-v1, EPYC-Milan-v2, EPYC-Genoa, EPYC-Genoa-v1)
+    --vcpu-sig  Guest vcpu signature value
+    --vcpu-family  Guest vcpu family
+    --vcpu-model  Guest vcpu model
+    --vcpu-stepping  Guest vcpu stepping
+    -t, --vmm-type  Type of guest vmm (QEMU, ec2, KRUN) [default: QEMU]
+    -o, --ovmf  OVMF file to calculate measurement from
+    -k, --kernel  Kernel file to calculate measurement from
+    -i, --initrd  Initrd file to calculate measurement from
+    -a, --append  Kernel command line in string format to calculate measurement from
+    -g, --guest-features  Hex representation of the guest kernel features expected to be included [default: 0x1]
+    --ovmf-hash  Precalculated hash of the OVMF binary
+    -f, --output-format  Output format (base64, hex). [default: hex]
+    -m, --measurement-file Optional file path where the measurement value can be stored in
+ 
+*snpguest generate ovmf-hash*::
+    usage: snpguest generate ovmf-hash [-o, --ovmf] [-f, --output--format] [--hash-file]
+    
+    Calculates the hash of an ovmf file.
+    User only needs to provide the file they want the hash for.
+    The hash will be printed in the console, if the user wishes to store the hash value they can provide a file path with [--hash-file] and the hash will get written there.
+    If the [--quiet] flag is used, nothing will be printed out.
+
+    options:
+    -h, --help  Show a help message
+    -o, --ovmf  OVMF file to generate hash for
+    -f, --output-format  Output format (base64, hex). [default: hex]
+    --hash-file Optional file path where the hash value can be stored in
+
+*snpguest generate id-block*::
+    usage: snpguest generate id-block $ID-BLOCK-KEY $AUTH-KEY $LAUNCH-DIGEST [-f, --family-id] [-m, --image-id] [-v, --version] [-s, --svn] [-p, --policy] 
+        [-i, --id-file] [-a, --auth-file]
+    
+    Calculates an id-block and auth-block for a secure guest.
+    User nees to provide a path to two different EC p384 keys in pem or der format. One will be for the id-block the other for the auth-block.
+    The user will also need to provide the launch digest (in either hex or base64 format) of the secure guest.
+    The user can generate the launch digest using the "generate measurement" command.
+    The user can provide optional id's for further verification using the [-f, --family-id] and [-m, image-id] paramerters.
+    The user can provide the security version number of the guest using [-s, --svn].
+    The user can specify the launch policy of the guest using the [-p, --policy] parameter..
+    The policy can be provided in either hex or decimal format.  It will default to 0x30000. 
+    For more information on the guest-policy, you can refer to: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf#page=27
+    The blocks will be printed in the console, if the user wishes to store the blocks values they can provide a file path with [-i, --id-file] for the id-block
+    and [-a, --auth-file] for the auth-block.
+    If the [--quiet] flag is used, nothing wibe printed out.
+
+    options:
+    -h, --help  Show a help message
+    -f, --family-id  Family ID of the guest provided by the guest owner. Has to be 16 characters
+    -m, --image-id  Image ID of the guest provided by the guest owner. Has to be 16 characters
+    -v, --version  Id-Block version. Currently only version 1 is available
+    -s, --svn  SVN (SECURITY VERSION NUMBER) of the guest
+    -p, --policy  Launch policy of the guest. Can provide in decimal or hex format
+    -i, --id-file Optional file where the Id-Block value can be stored in
+    -a, --auth-file Optional file where the Auth-Block value can be stored in
+
+*snpguest generate key-digest*::
+    usage: snpguest generate key-digest $KEY-PATH [-d, --key-digest-file]
+    
+    Generates an SEV key digest for a provided EC p384 key.
+    User needs to provide a path to the key 
+    The key has to be a EC p384 key in either pem or der format.
+    The digest will be printed in the console, if the user wishes to store the digest value they can provide a file path with [-d, --key-digest-file]
+    If the [--quiet] flag is used, nothing wibe printed out.
+
+    options:
+    -h, --help  Show a help message
+    -d, --key-digest-file  File to store the key digest in
 
 *snpguest guest display report*::
     usage: snpguest display report $ATT_REPORT_PATH

--- a/docs/snpguest.1.adoc
+++ b/docs/snpguest.1.adoc
@@ -189,7 +189,7 @@ COMMANDS
         [-i, --id-file] [-a, --auth-file]
     
     Calculates an id-block and auth-block for a secure guest.
-    User nees to provide a path to two different EC p384 keys in pem or der format. One will be for the id-block the other for the auth-block.
+    User needs to provide a path to two different EC p384 keys in pem or der format. One will be for the id-block the other for the auth-block.
     The user will also need to provide the launch digest (in either hex or base64 format) of the secure guest.
     The user can generate the launch digest using the "generate measurement" command.
     The user can provide optional id's for further verification using the [-f, --family-id] and [-m, image-id] paramerters.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod display;
 mod fetch;
 mod key;
 mod ok;
+mod preattestation;
 mod report;
 mod verify;
 
@@ -16,6 +17,7 @@ use certs::CertificatesArgs;
 use display::DisplayCmd;
 use fetch::FetchCmd;
 use key::KeyArgs;
+use preattestation::PreAttestationCmd;
 use report::ReportArgs;
 use verify::VerifyCmd;
 
@@ -60,6 +62,10 @@ enum SnpGuestCmd {
 
     /// Probe system for SEV-SNP support.
     Ok,
+
+    /// Generate Pre-Attestation components
+    #[command(subcommand)]
+    Generate(PreAttestationCmd),
 }
 
 fn main() -> Result<()> {
@@ -81,6 +87,7 @@ fn main() -> Result<()> {
         SnpGuestCmd::Display(subcmd) => display::cmd(subcmd, snpguest.quiet),
         SnpGuestCmd::Key(args) => key::get_derived_key(args),
         SnpGuestCmd::Ok => ok::cmd(snpguest.quiet),
+        SnpGuestCmd::Generate(subcmd) => preattestation::cmd(subcmd, snpguest.quiet),
     };
 
     if let Err(ref e) = status {

--- a/src/preattestation.rs
+++ b/src/preattestation.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file defines the CLI for pre-attestation related processes, such as calculating the measurement or generating an ID-BLOCK
+
+use super::*;
+use base64::{engine::general_purpose, Engine as _};
+use clap_num::maybe_hex;
+use sev::{
+    firmware::guest::GuestPolicy,
+    measurement::{
+        idblock::{generate_key_digest, snp_calculate_id},
+        idblock_types::{FamilyId, ImageId},
+        snp::{calc_snp_ovmf_hash, snp_calc_launch_digest, SnpLaunchDigest, SnpMeasurementArgs},
+        vcpu_types::{cpu_sig, CpuType},
+        vmsa::{GuestFeatures, VMMType},
+    },
+};
+use std::{fs::OpenOptions, io::Write, path::PathBuf};
+
+#[derive(Subcommand)]
+pub enum PreAttestationCmd {
+    /// Calculate the Measurement of a confidential VM with the supplied parameters
+    Measurement(measurement::Args),
+
+    /// Calculated the hash of an OVMF file
+    OvmfHash(ovmf_hash::Args),
+
+    /// Generate an ID-Block and Auth-Block for a confidential VM with the supplied parameters
+    IdBlock(idblock::Args),
+
+    /// Generate a SEV key digest for the provided openssl key.
+    KeyDigest(keydigest::Args),
+}
+
+pub fn cmd(cmd: PreAttestationCmd, quiet: bool) -> Result<()> {
+    match cmd {
+        PreAttestationCmd::Measurement(args) => measurement::generate_measurement(args, quiet),
+        PreAttestationCmd::OvmfHash(args) => ovmf_hash::generate_ovmf_hash(args, quiet),
+        PreAttestationCmd::IdBlock(args) => idblock::generate_id_block(args, quiet),
+        PreAttestationCmd::KeyDigest(args) => keydigest::calculate_key_digest(args, quiet),
+    }
+}
+
+mod measurement {
+
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[derive(Parser, Debug)]
+    pub struct Args {
+        /// Number of guest vcpus
+        #[arg(short, long, default_value = "1")]
+        pub vcpus: u32,
+
+        /// Type of guest vcpu (EPYC, EPYC-v1, EPYC-v2, EPYC-IBPB, EPYC-v3, EPYC-v4,
+        /// EPYC-Rome, EPYC-Rome-v1, EPYC-Rome-v2, EPYC-Rome-v3, EPYC-Milan, EPYC-
+        /// Milan-v1, EPYC-Milan-v2, EPYC-Genoa, EPYC-Genoa-v1)
+        #[arg(long, value_name = "vcpu-type", 
+            conflicts_with_all = ["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"], 
+            required_unless_present_all(["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"]))]
+        pub vcpu_type: Option<String>,
+
+        /// Guest vcpu signature value
+        #[arg(long, value_name = "vcpu-sig", conflicts_with_all = ["vcpu_type", "vcpu_family", "vcpu_model", "vcpu_stepping"])]
+        pub vcpu_sig: Option<i32>,
+
+        /// Guest vcpu family
+        #[arg(long, value_name = "vcpu-family", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_model", "vcpu_stepping"])]
+        pub vcpu_family: Option<i32>,
+
+        /// Guest vcpu model
+        #[arg(long, value_name = "vcpu-model", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_family", "vcpu_stepping"])]
+        pub vcpu_model: Option<i32>,
+
+        /// Guest vcpu stepping.
+        #[arg(long, value_name = "vcpu-stepping", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_family", "vcpu_model"])]
+        pub vcpu_stepping: Option<i32>,
+
+        /// Type of guest vmm (QEMU, ec2, KRUN)
+        #[arg(long, short = 't', value_name = "vmm-type")]
+        pub vmm_type: Option<String>,
+
+        /// OVMF file to calculate measurement from
+        #[arg(short, long, value_name = "ovmf", required = true)]
+        pub ovmf: PathBuf,
+
+        /// Kernel file to calculate measurement from
+        #[arg(short, long, value_name = "kernel", requires_all = ["append", "initrd"])]
+        pub kernel: Option<PathBuf>,
+
+        /// Initrd file to calculate measurement from
+        #[arg(short, long, value_name = "initrd", requires_all = ["kernel", "append"])]
+        pub initrd: Option<PathBuf>,
+
+        /// Kernel command line to calculate measurement from
+        #[arg(short, long, value_name = "append", requires_all = ["kernel", "initrd"])]
+        pub append: Option<String>,
+
+        /// Hex representation of the guest kernel features expected to be included, defaults to 0x1
+        #[arg(short, long, value_name = "guest-features", value_parser=maybe_hex::<u64>)]
+        pub guest_features: Option<u64>,
+
+        /// Precalculated hash of the OVMF binary
+        #[arg(
+            long,
+            value_name = "ovmf-hash",
+            conflicts_with = "ovmf",
+            required_unless_present = "ovmf"
+        )]
+        pub ovmf_hash: Option<String>,
+
+        ///Choose output format (base64, hex).
+        #[arg(long, short = 'f', value_name = "output-format", default_value = "hex")]
+        pub output_format: String,
+
+        /// Optional file path where measurement value can be stored in
+        #[arg(short = 'm', long, value_name = "measurement-file")]
+        pub measurement_file: Option<PathBuf>,
+    }
+
+    pub fn generate_measurement(args: Args, quiet: bool) -> Result<()> {
+        // Get VCPU type from either string, signature or family, model and step.
+        let vcpu_type = if let Some(v_type) = args.vcpu_type {
+            CpuType::try_from(v_type.as_str())?
+        } else if let Some(sig) = args.vcpu_sig {
+            CpuType::try_from(sig)?
+        } else if let Some(family) = args.vcpu_family {
+            let sig = cpu_sig(
+                family,
+                args.vcpu_model.unwrap(),
+                args.vcpu_stepping.unwrap(),
+            );
+            CpuType::try_from(sig)?
+        } else {
+            return Err(anyhow::anyhow!("No VCPU Type provided"));
+        };
+
+        let guest_features = match args.guest_features {
+            Some(gf) => GuestFeatures(gf),
+            None => GuestFeatures::default(),
+        };
+
+        let append: Option<&str> = args.append.as_deref();
+
+        let ovmf_hash_str: Option<&str> = args.ovmf_hash.as_deref();
+
+        let vmm_type = match args.vmm_type {
+            Some(vmm_type) => Some(VMMType::from_str(vmm_type.as_str())?),
+            None => None,
+        };
+
+        let collected_args = SnpMeasurementArgs {
+            vcpus: args.vcpus,
+            vcpu_type,
+            ovmf_file: args.ovmf,
+            guest_features,
+            kernel_file: args.kernel,
+            initrd_file: args.initrd,
+            append,
+            ovmf_hash_str,
+            vmm_type,
+        };
+
+        let launch_digest = match snp_calc_launch_digest(collected_args) {
+            Ok(ld) => {
+                if args.output_format == "hex" {
+                    format!("0x{}", ld.get_hex_ld())
+                } else {
+                    general_purpose::STANDARD.encode(ld.get_hex_ld().as_bytes())
+                }
+            }
+            Err(e) => return Err(anyhow::anyhow!("Error calculating the measurement:{e}")),
+        };
+
+        // If measurement file is provided, store measurement value in the file
+        if let Some(measurement_file) = args.measurement_file {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(measurement_file)?;
+
+            file.write_all(launch_digest.as_bytes())
+                .expect("Unable to write data");
+        }
+
+        // Print measurement
+        if !quiet {
+            println!("{}", launch_digest);
+        }
+
+        Ok(())
+    }
+}
+
+mod ovmf_hash {
+    use super::*;
+
+    #[derive(Parser)]
+    pub struct Args {
+        /// Path to OVMF file to calculate hash from
+        #[arg(short, long, value_name = "ovmf", required = true)]
+        pub ovmf: PathBuf,
+
+        /// Choose output format (base64, hex). Defaults to hex
+        #[arg(short = 'f', long, value_name = "output-format", default_value = "hex")]
+        pub output_format: String,
+
+        /// Optional file where hash value can be stored in
+        #[arg(long, value_name = "hash-file")]
+        pub hash_file: Option<PathBuf>,
+    }
+    pub fn generate_ovmf_hash(args: Args, quiet: bool) -> Result<()> {
+        let ovmf_hash = match calc_snp_ovmf_hash(args.ovmf) {
+            Ok(ld) => {
+                if args.output_format == "hex" {
+                    ld.get_hex_ld()
+                } else {
+                    general_purpose::STANDARD.encode(ld.get_hex_ld().as_bytes())
+                }
+            }
+            Err(e) => return Err(anyhow::anyhow!("Error calculating the measurement:{e}")),
+        };
+
+        if let Some(hash_file) = args.hash_file {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(hash_file)?;
+
+            file.write_all(ovmf_hash.as_bytes())
+                .expect("Unable to write data");
+        }
+
+        if !quiet {
+            println!("{}", ovmf_hash);
+        }
+
+        Ok(())
+    }
+}
+
+mod idblock {
+    use hex::FromHex;
+
+    use super::*;
+
+    #[derive(Parser)]
+    pub struct Args {
+        /// Path to the Id-Block key
+        #[arg(value_name = "id-block-key", required = true)]
+        pub id_block_key: PathBuf,
+
+        /// Path to the Auth-Block key
+        #[arg(value_name = "auth-key", required = true)]
+        pub auth_key: PathBuf,
+
+        /// Guest launch measurement in either Base64 encoding or hex (if hex prefix with 0x)
+        #[arg(value_name = "launch-digest", required = true)]
+        pub launch_digest: String,
+
+        /// Family ID of the guest provided by the guest owner. Has to be 16 characters.
+        #[arg(short, long, value_name = "familiy-id")]
+        pub family_id: Option<String>,
+
+        /// Image ID of the guest provided by the guest owner. Has to be 16 characters.
+        #[arg(short = 'm', long, value_name = "image-id")]
+        pub image_id: Option<String>,
+
+        /// Id-Block version. Currently only version 1 is available
+        #[arg(short, long, value_name = "version")]
+        pub version: Option<u32>,
+
+        /// SVN of the guest
+        #[arg(short, long, value_name = "svn")]
+        pub svn: Option<u32>,
+
+        /// Launch policy of the guest. Can provide in decimal or hex format.
+        #[arg(short, long, value_name = "policy", value_parser=maybe_hex::<u64>)]
+        pub policy: Option<u64>,
+
+        /// Optional file where the Id-Block value can be stored in
+        #[arg(short, long, value_name = "id-block-file")]
+        pub id_file: Option<PathBuf>,
+
+        /// Optional file where the Auth-Block value can be stored in
+        #[arg(short, long, value_name = "auth-info-file")]
+        pub auth_file: Option<PathBuf>,
+    }
+
+    pub fn generate_id_block(args: Args, quiet: bool) -> Result<()> {
+        let ld =
+            if &args.launch_digest[..args.launch_digest.char_indices().nth(2).unwrap().0] == "0x" {
+                SnpLaunchDigest::new(Vec::from_hex(&args.launch_digest[2..])?.try_into()?)
+            } else {
+                SnpLaunchDigest::new(
+                    general_purpose::STANDARD
+                        .decode(args.launch_digest)?
+                        .try_into()?,
+                )
+            };
+
+        let family_id = match args.family_id {
+            Some(family) => {
+                if family.chars().count() == 16 {
+                    Some(FamilyId::new(family.as_bytes().try_into()?))
+                } else {
+                    return Err(anyhow::anyhow!("Invalid Family Id length!"));
+                }
+            }
+            None => None,
+        };
+
+        let image_id = match args.image_id {
+            Some(image) => {
+                if image.chars().count() == 16 {
+                    Some(ImageId::new(image.as_bytes().try_into()?))
+                } else {
+                    return Err(anyhow::anyhow!("Invalid Image Id length!"));
+                }
+            }
+            None => None,
+        };
+
+        let policy = args.policy.map(GuestPolicy);
+
+        let measurements = snp_calculate_id(
+            Some(ld),
+            family_id,
+            image_id,
+            args.svn,
+            policy,
+            args.id_block_key,
+            args.auth_key,
+        )?;
+
+        // Formatted in Base-64 since it's the format QEMU takes.
+        let id_block_string =
+            general_purpose::STANDARD.encode(bincode::serialize(&measurements.id_block)?);
+        let id_auth_string =
+            general_purpose::STANDARD.encode(bincode::serialize(&measurements.id_auth)?);
+
+        // If Id-Block file is provided, store Id-Block value in the file
+        if let Some(id_file) = args.id_file {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(id_file)?;
+
+            file.write_all(id_block_string.as_bytes())
+                .expect("Unable to write data");
+        }
+
+        // If Auth-Block file is provided, store Auth-Block value in the file
+        if let Some(auth_file) = args.auth_file {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(auth_file)?;
+
+            file.write_all(id_auth_string.as_bytes())
+                .expect("Unable to write data");
+        }
+
+        if !quiet {
+            println!("ID-BLOCK:");
+            println!("{}", id_block_string);
+            println!("AUTH-BLOCK:");
+            println!("{}", id_auth_string);
+        }
+        Ok(())
+    }
+}
+
+mod keydigest {
+    use super::*;
+
+    #[derive(Parser)]
+    pub struct Args {
+        /// Path to key to generate hash for
+        #[arg(value_name = "key", required = true)]
+        pub key: PathBuf,
+
+        /// File to store the key digest in
+        #[arg(short = 'd', long, value_name = "key-digest-file")]
+        pub key_digest_file: Option<PathBuf>,
+    }
+
+    pub fn calculate_key_digest(args: Args, quiet: bool) -> Result<()> {
+        let kd = generate_key_digest(args.key)?;
+
+        let key_digest_string = hex::encode::<Vec<u8>>(kd.try_into().unwrap());
+
+        if let Some(key_digest_file) = args.key_digest_file {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(key_digest_file)?;
+
+            file.write_all(key_digest_string.as_bytes())
+                .expect("Unable to write data");
+        }
+
+        if !quiet {
+            println!("Key Digest:");
+            println!("{}", key_digest_string);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Added functionality to generate different pre-attestation components

- Generate a guest launch digest (measurement)
- Generate an ID-BLOCK and AUTH-BLOCK
- Generate an OVMF-hash
- Generate key-digests for openssl keys