### PR TITLE
Adding Turin support and updating ASK CN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "snpguest"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -277,7 +277,7 @@ mod attestation {
         {
             match val.to_lowercase() {
                 x if x.contains("ark") => Ok(CertType::ARK),
-                x if x.contains("ask") => Ok(CertType::ASK),
+                x if x.contains("ask") | x.contains("sev") => Ok(CertType::ASK),
                 x if x.contains("vcek") => Ok(CertType::VCEK),
                 x if x.contains("vlek") => Ok(CertType::VLEK),
                 x if x.contains("crl") => Ok(CertType::CRL),


### PR DESCRIPTION
Adding Turin support for certificate fetching.

A recent update to the CA certificates changed the name of the ASK common name to SEV-<processor name>, we added that option to our parser so that certificate verification still works.