### PR TITLE
Fix certificate fetch bug for Turin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97bd0b2e2d937951add10c8512a2dacc6ad29b39e5c5f26565a3e443329857d"
+checksum = "b06afe5192a43814047ea0072f4935f830a1de3c8cb43b56c90ae6918468b94d"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hyperv = ["tss-esapi"]
 clap = { version = "4.5", features = [ "derive" ] }
 env_logger = "0.10.0"
 anyhow = "1.0.69"
-sev = { version = "4.0", default-features = false, features = ['openssl','snp']}
+sev = { version = "5.0.0", default-features = false, features = ['openssl','snp']}
 nix = "^0.23"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "^1.2.1"


### PR DESCRIPTION
Adding the new from_pem_bytes function to the fetch function for the CA in order to solve the issue of different sized certificates for Turin.

I wanted to completely remove the openssl dependency on this PR, but I'm waiting on https://github.com/virtee/sev/pull/266

We could merge this now and then on the next release remove that dependency

