### PR TITLE
Update version (0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snpguest"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snpguest"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["The VirTEE Project Developers"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumping crate version to 0.9.0 in order to cut release.