### PR TITLE
fix(hyperv): downgrade VMPL check from error to warning

### DIFF
--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -98,7 +98,7 @@ pub mod report {
 
     pub fn get(vmpl: u32) -> Result<AttestationReport> {
         if vmpl > 0 {
-            return Err(anyhow!("Azure vTPM attestation report requires VMPL 0"));
+            eprintln!("Warning: --vmpl argument was ignored because attestation report is pre-fetched at VMPL 0 and stored in vTPM.");
         }
         let bytes = tpm2_read().context("unable to read attestation report bytes from vTPM")?;
 


### PR DESCRIPTION
Closes #108 

### Summary

This PR downgrades the VMPL check from an error to a warning when using the `--platform` flag. The attestation report is always fetched from the vTPM at VMPL 0, so specifying `--vmpl` has no actual effect in this context.

### What's changed

| Flags (snpguest report) | Previous behavior | Behavior in this PR   |
| :--                     | :--               | :--                   |
| `-p -v 0`               | ✅ Success        | ✅ Success (unchanged) |
| `-p -v <non-zero>`      | ❌ Error          | ⚠️ Warning (changed)   |

If a non-zero value is specified for the `--vmpl` argument, a warning message is now displayed. This makes it clear that the report is obtained from VMPL 0 and that the reported VMPL is of vTPM (rather than the guest OS).

### Test
```bash
sudo snpguest report report.bin request-data.bin -p -v 0
# Success
sudo snpguest report report.bin request-data.bin -p -v 1
# Warning: --vmpl argument was ignored because attestation report is pre-fetched at VMPL 0 and stored in vTPM.
```

## Summary by Sourcery

Bug Fixes:
- Change the VMPL>0 error into a warning and proceed with the attestation report at VMPL 0