### PR TITLE
feat: support SEV-SNP Report Version 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,8 +1528,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1750ba11a6a6bba3c220da714caa0226aa34e417dce3975d2953062240717dea"
+source = "git+https://github.com/virtee/sev#3068e8d7eb28afef078d47fa5284d3ef9da210ce"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hyperv = ["tss-esapi"]
 clap = { version = "4.5", features = [ "derive" ] }
 env_logger = "0.10.0"
 anyhow = "1.0.69"
-sev = { version = "6.2.1", default-features = false, features = ['openssl','snp']}
+sev = { git = "https://github.com/virtee/sev", default-features = false, features = ['openssl','snp']}
 nix = "^0.23"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "^1.2.1"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ snpguest fetch <SUBCOMMAND>
 
 ### 5. `key` 
 
-Creates the derived key based on input parameters and stores it. `$KEY_PATH` is the path to store the derived key. `$ROOT_KEY_SELECT` is the root key from which to derive the key (either "vcek" or "vmrk"). The `--guest_field_select` option specifies which Guest Field Select bits to enable as a 6-digit binary string. Each of the 6 bits from *right to left* correspond to Guest Policy, Image ID, Family ID, Measurement, SVN and TCB Version respectively. For each bit, 0 denotes off, and 1 denotes on. The `--guest_svn` option specifies the guest SVN to mix into the key, and the `--tcb_version` option specifies the TCB version to mix into the derived key. The `--vmpl` option specifies the VMPL level the Guest is running on and defaults to 1.
+Creates the derived key based on input parameters and stores it. `$KEY_PATH` is the path to store the derived key. `$ROOT_KEY_SELECT` is the root key from which to derive the key (either "vcek" or "vmrk"). The `--guest_field_select` option specifies which Guest Field Select bits to enable as a 6-digit binary string. Each of the 6 bits from *right to left* correspond to Guest Policy, Image ID, Family ID, Measurement, SVN and TCB Version respectively. For each bit, 0 denotes off, and 1 denotes on. The `--guest_svn` option specifies the guest SVN to mix into the key, the `--tcb_version` option specifies the TCB version to mix into the derived key, and the `--launch_mit_vector` option specifies the launch mitigation vector value to mix into the derived key. The `--vmpl` option specifies the VMPL level the Guest is running on and defaults to 1.
 
 
 **Usage**
@@ -180,6 +180,7 @@ snpguest key $KEY_PATH $ROOT_KEY_SELECT [-v, --vmpl] [-g, --guest_field_select] 
 | `-g, --guest_field_select $GFS` | option specifies which Guest Field Select bits to enable as a 6-digit binary string. For each bit, 0 denotes off, and 1 denotes on. | — |
 | `-s, --guest_svn $GSVN` | option specifies the guest SVN to mix into the key. | — |
 | `-t, --tcb_version $TCBV` | option specifies the TCB version to mix into the derived key. | — |
+| `-l, --launch_mit_vector $LMV` | option specifies the launch mitigation vector value to mix into the derived key (only available for report version 5). | — |
 
 **Guest Field Select**
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -32,6 +32,10 @@ pub struct KeyArgs {
     /// Specify the TCB version to mix into the derived key. Must not exceed CommittedTcb.
     #[arg(short, long = "tcb_version")]
     pub tcbv: Option<u64>,
+
+    /// Specify the launch mitigation vector to mix into the derived key.
+    #[arg(short, long = "launch_mit_vector")]
+    pub lmv: Option<u64>,
 }
 
 pub fn get_derived_key(args: KeyArgs) -> Result<()> {
@@ -68,7 +72,14 @@ pub fn get_derived_key(args: KeyArgs) -> Result<()> {
 
     let tcbv: u64 = args.tcbv.unwrap_or(0);
 
-    let request = DerivedKey::new(root_key_select, GuestFieldSelect(gfs), vmpl, gsvn, tcbv);
+    let request = DerivedKey::new(
+        root_key_select,
+        GuestFieldSelect(gfs),
+        vmpl,
+        gsvn,
+        tcbv,
+        args.lmv,
+    );
     let mut sev_fw = Firmware::open().context("failed to open SEV firmware device.")?;
     let derived_key: [u8; 32] = sev_fw
         .get_derived_key(None, request)


### PR DESCRIPTION
This PR adds support for SEV-SNP Report Version 5 by updating the code and bumping the `sev` crate.

Fixes #113

### What's changed
- Bump the `sev` crate to the latest version
- Modifies the code to support new fields introduced in Report Version 5 (e.g., `launch_mit_vector`)
- Update `README.md` to reflect these changes

### ⚠️ Temporary Measure (as of 7 Aug 2025)
This PR (draft) is a **temporary workaround** using an unreleased version of `sev`. Once an official release of the `sev` crate with Report V5 support becomes available, I will:
- Revert the GitHub dependency in `Cargo.toml` to a versioned release.
- Regenerate `Cargo.lock` accordingly.