### PR TITLE
fix(verify): make `SnpOid::oid` return `Oid<'static>` to silence lifetime warning

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -167,7 +167,7 @@ mod attestation {
 
     // OID extensions for the VCEK, will be used to verify attestation report
     impl SnpOid {
-        fn oid(&self) -> Oid {
+        fn oid(&self) -> Oid<'static> {
             match self {
                 SnpOid::BootLoader => oid!(1.3.6 .1 .4 .1 .3704 .1 .3 .1),
                 SnpOid::Tee => oid!(1.3.6 .1 .4 .1 .3704 .1 .3 .2),


### PR DESCRIPTION
This PR removes the `mismatched_lifetime_syntaxes` warning that appears on every build:

```plaintext
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/verify.rs:170:16
    |
170 |         fn oid(&self) -> Oid {
    |                ^^^^^     --- the same lifetime is hidden here
    |                |
    |                the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
170 |         fn oid(&self) -> Oid<'_> {
    |                             ++++
```

The warning stems from returning `Oid` without an explicit lifetime while the same lifetime is written explicitly on `&self`. Adding a `’static` lifetime resolves the mismatch because every OID literal we construct is a compile-time constant that lives for the entire program.

Fixes #118 