### PR TITLE
chore(main): remove unnecessary import `clap::arg`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use report::ReportArgs;
 use verify::VerifyCmd;
 
 use anyhow::{Context, Result};
-use clap::{arg, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
This PR removes an unnecessary import of `clap::arg` in `main.rs`. Attribute macros `#[arg(...)]` do not require `use clap::arg`, which may cause error when testing with newer toolchain e.g. `1.92.0-nightly (595b9a498 2025-10-03)`:

```console
Error:   --> src/main.rs:25:12
   |
25 | use clap::{arg, Parser, Subcommand, ValueEnum};
   |            ^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`
```

Removing this keeps CI green across all toolchains (stable, beta, nightly and MSRV 1.86.0)