### PR TITLE
ci: replace deprecated `actions-rs/toolchain` and bump `actions/checkout`

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,6 +1,5 @@
-permissions:  
-  contents: write  
-  
+name: Build and Release  
+
 on:  
   workflow_dispatch:  
     inputs:  
@@ -19,32 +18,27 @@ on:
   pull_request:  
     branches: [main, master]  
   
-name: Build and Release  
+permissions:  
+  contents: write  
   
 jobs:  
   build:  
     name: Build and Test  
     runs-on: ubuntu-latest  
-    steps:  
+    steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install -y asciidoctor musl-tools  
       - uses: actions/checkout@v4  
-      - uses: actions-rs/toolchain@v1  
+      - uses: dtolnay/rust-toolchain@stable
         with:  
           toolchain: stable  
-          target: x86_64-unknown-linux-musl  
-          override: true  
-  
+          target: x86_64-unknown-linux-musl
+      
       - name: Build  
-        uses: actions-rs/cargo@v1  
-        with:  
-          command: build  
-          args: --release --target x86_64-unknown-linux-musl  
+        run: cargo build --release --target x86_64-unknown-linux-musl
   
       - name: Test  
-        uses: actions-rs/cargo@v1  
-        with:  
-          command: test  
-          args: --release --target x86_64-unknown-linux-musl  
+        run: cargo test --release --target x86_64-unknown-linux-musl
   
       - name: Verify binary exists  
         run: ls -la target/x86_64-unknown-linux-musl/release/snpguest  

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,6 +3,9 @@ name: Sign-off Check
 on:
   pull_request:
 
+permissions:  
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,35 +1,31 @@
-on: [push, pull_request]
 name: lint
+
+on: [push, pull_request]
+
+permissions:  
+  contents: read
+
 jobs:
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
           toolchain: nightly
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install -y asciidoctor
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
           toolchain: 1.86.0
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --locked --all-targets -- -D clippy::all -D unused_imports -D warnings
+      - run: cargo clippy --locked --all-targets -- -D clippy::all -D unused_imports -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,22 @@
-on: [push, pull_request]
 name: test
+
+on: [push, pull_request]
+
+permissions:  
+  contents: read
+
 jobs:
   test:
     name: ${{ matrix.toolchain }} (${{ matrix.profile.name }})
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install -y asciidoctor
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: ${{ matrix.profile.flag }}
+      - run: cargo test ${{ matrix.profile.flag }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow:
- Replace deprecated `actions-rs/toolchain` with `dtolnay/rust-toolchain`
- Bump `actions/checkout` from v2 to v4

This avoids deprecation notices for these deprecated actions and prepares for future retirement.

Additional cleanup included:
- Align workflow key order: `name` → `on` → `permissions` → `jobs`
- Explicitly restrict permissions to `contents: read` where write access is unnecessary (`lint.yml`, `test.yml` and `dco.yml`)
- Add `apt-get update` before `apt-get install` for robustness

### Note
Two actively maintained replacements exist for `actions-rs/toolchain`:
1. `dtolnay/rust-toolchain`
2. `actions-rust-lang/setup-rust-toolchain`

Since the `virtee/sev` repository already uses `dtolnay/rust-toolchain`, this PR adopts the same action for consistency across VirTEE projects.