### PR TITLE
refactor(certs): remove redundant branch in file-write logic

### DIFF
--- a/src/certs.rs
+++ b/src/certs.rs
@@ -149,15 +149,14 @@ pub fn write_cert(
     let cert_path: PathBuf = path.join(format!("{cert_str}.{encoding}"));
 
     // Write cert into directory
-    let mut file = if cert_path.exists() {
-        std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(cert_path)
-            .context(format!("Unable to overwrite {cert_str} cert contents"))?
-    } else {
-        fs::File::create(cert_path).context(format!("Unable to create {cert_str} certificate"))?
-    };
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&cert_path)
+        .context(format!(
+            "unable to create or overwrite {cert_str} certificate"
+        ))?;
 
     file.write(&bytes)
         .context(format!("unable to write data to file {:?}", file))?;


### PR DESCRIPTION
During the review of PR #124 unnecessary conditional branching was discovered in `src/certs.rs`. This pull request removes that branch to simplify the write path while preserving existing behaviour.

### Testing
#### Environment
- VM: Google Cloud Platform N2D (Milan)
- OS: Ubuntu 24.04.1
- Kernel: 6.14.0-1017-gcp 

#### Steps
```bash
# 1. Normal download succeeds
snpguest fetch ca pem . milan
# → ark.pem and ask.pem are created

# 2. Make ark.pem read-only
chmod -w ark.pem

# 3. Attempt to overwrite; expect a write-error
snpguest fetch ca pem . milan
```

#### Output

```console
$ chmod -w ark.pem
$ snpguest fetch ca pem . milan
ERROR: unable to create or overwrite ark certificate
because: Permission denied (os error 13)
Error: unable to create or overwrite ark certificate

Caused by:
    Permission denied (os error 13
```