### PR TITLE
preattestation: fix family_id and image_id parsing

### DIFF
--- a/src/preattestation.rs
+++ b/src/preattestation.rs
@@ -274,11 +274,11 @@ mod idblock {
         #[arg(value_name = "launch-digest", required = true)]
         pub launch_digest: String,
 
-        /// Family ID of the guest provided by the guest owner. Has to be 16 characters.
+        /// Family ID of the guest provided by the guest owner in hex. Has to be 32 characters (16 bytes).
         #[arg(short, long, value_name = "family-id")]
         pub family_id: Option<String>,
 
-        /// Image ID of the guest provided by the guest owner. Has to be 16 characters.
+        /// Image ID of the guest provided by the guest owner in hex. Has to be 32 characters (16 bytes).
         #[arg(short = 'm', long, value_name = "image-id")]
         pub image_id: Option<String>,
 
@@ -316,23 +316,25 @@ mod idblock {
             };
 
         let family_id = match args.family_id {
-            Some(family) => {
-                if family.chars().count() == 16 {
-                    Some(FamilyId::new(family.as_bytes().try_into()?))
-                } else {
-                    return Err(anyhow::anyhow!("Invalid Family Id length!"));
+            Some(s) => {
+                if s.len() != 32 {
+                    return Err(anyhow::anyhow!("Family ID must be 32 hex chars"));
                 }
+                let bytes: [u8; 16] =
+                    <[u8; 16]>::from_hex(&s).map_err(|_| anyhow::anyhow!("Invalid hex"))?;
+                Some(FamilyId::new(bytes))
             }
             None => None,
         };
 
         let image_id = match args.image_id {
-            Some(image) => {
-                if image.chars().count() == 16 {
-                    Some(ImageId::new(image.as_bytes().try_into()?))
-                } else {
-                    return Err(anyhow::anyhow!("Invalid Image Id length!"));
+            Some(s) => {
+                if s.len() != 32 {
+                    return Err(anyhow::anyhow!("Image ID must be 32 hex chars"));
                 }
+                let bytes: [u8; 16] =
+                    <[u8; 16]>::from_hex(&s).map_err(|_| anyhow::anyhow!("Invalid hex"))?;
+                Some(ImageId::new(bytes))
             }
             None => None,
         };


### PR DESCRIPTION
AMD defines the `family_id` and `image_id` fields as 16 bytes long. Therefore, in the command-line tool, we should expect 32 hexadecimal characters to convert this into a 16-byte sequence. This patch addresses the issue when only 16 characters are parsed.

I assume the intention of the original code was to accept the image_id in ASCII, as a name, but this is incorrect. If a non-ASCII string of 16 characters is passed as --image-id, the call to try_into() will likely fail because the UTF-8 encoding produces more than 16 bytes. Another concern is that generating a random image_id, e.g. a UUID, would naturally fit in 16 bytes, but it cannot be passed safely through this interface because it is limited to ASCII-only characters. This commit replaces the logic with a proper conversion from a 32-character hex string to 16 bytes.

Note: This change breaks compatibility with the previous interface. The new implementation expects a 32-character hex string that converts to exactly 16 bytes, so old ASCII names will no longer work.

Fixes: https://github.com/virtee/snpguest/issues/138

