### PR TITLE
CI: Enable caching of Rust toolchain and build artifacts for CI/CD performance

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - run: sudo apt-get update && sudo apt-get install -y musl-tools  
       - uses: actions/checkout@v4  
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:  
           toolchain: stable  
           target: x86_64-unknown-linux-musl

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest  
     steps:
       - run: sudo apt-get update && sudo apt-get install -y musl-tools  
-      - uses: actions/checkout@v4  
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:  
           toolchain: stable  
@@ -43,7 +43,7 @@ jobs:
         run: ls -la target/x86_64-unknown-linux-musl/release/snpguest  
   
       - name: Upload Build Artifact  
-        uses: actions/upload-artifact@v4  
+        uses: actions/upload-artifact@v7
         with:  
           name: snpguest-binary  
           path: target/x86_64-unknown-linux-musl/release/snpguest  
@@ -54,10 +54,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')  
     runs-on: ubuntu-latest  
     steps:  
-      - uses: actions/checkout@v4  
+      - uses: actions/checkout@v6
   
       - name: Download Build Artifact  
-        uses: actions/download-artifact@v4  
+        uses: actions/download-artifact@v8
         with:  
           name: snpguest-binary  
           path: ./  
@@ -68,7 +68,7 @@ jobs:
           chmod +x ./snpguest  
   
       - name: Create GitHub Release  
-        uses: softprops/action-gh-release@v2  
+        uses: softprops/action-gh-release@v2
         with:  
           files: ./snpguest  
           generate_release_notes: true  

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
           toolchain: nightly
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
           toolchain: 1.86.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
@@ -21,7 +21,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: enarx/spdx@master
         with:
           licenses: Apache-2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo test ${{ matrix.profile.flag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.toolchain }} (${{ matrix.profile.name }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}


### PR DESCRIPTION
This PR switches CI workflows from `dtolnay/rust-toolchain` to `actions-rust-lang/setup-rust-toolchain`, which enables built-in caching (via `Swatinem/rust-cache` internally) for the Rust toolchain and Cargo build artifacts to significantly speed up CI/CD runs.

This PR bumps each `actions/*` action from v4 to its latest version to avoid dependencies on Node 20, which is nearing its end-of-life (Apr 30, 2026).

Fixes #148.

### Changes

- `dtolnay/rust-toolchain@stable` → `actions-rust-lang/setup-rust-toolchain@v1`
- `actions/checkout`: `v4` → `v6`
- `actions/upload-artifact`: `v4` → `v7`
- `actions/download-artifact`: `v4` → `v8`
- (Other change) Delete trailing spaces
