### PR TITLE
docs: add Rustdoc comments and CI support for documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Rustdoc
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+
+jobs:
+  rdme:
+    name: cargo rdme
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+      - run: cargo install cargo-rdme
+      - run: cargo rdme --check
+
+  rustdoc:
+    name: cargo doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          toolchain: 1.86.0
+      - run: sudo apt-get update && sudo apt-get install -y pkg-config libtss2-dev
+      - run: cargo doc --no-deps --all-features

--- a/README.md
+++ b/README.md
@@ -1,456 +1,249 @@
+<!-- cargo-rdme start -->
+
 # snpguest
 
-`snpguest` is a Command Line Interface utility for managing an AMD SEV-SNP enabled guest. This tool allows users to interact with the AMD SEV-SNP guest firmware device enabling various operations such as: attestation, certificate management, derived key fetching, and more.
+`snpguest` is a Command Line Interface utility for managing an AMD SEV-SNP
+enabled guest. This tool allows users to interact with the AMD SEV-SNP guest
+firmware device (`/dev/sev-guest`) enabling various operations such as:
 
-- [Usage](#usage)
-  - [1. help](#1-help)
-  - [2. certificates](#2-certificates)
-  - [3. display](#3-display)
-  - [4. fetch](#4.fetch)
-  - [5. key](#5-key)
-  - [6. report](#6-report)
-  - [7. verify](#7-verify)
-  - [Global Options](#global-options)
-- [Extended Attestation Workflow](#extended-attestation-workflow)
-- [Regular Attestation Workflow](#regular-attestation-workflow)
-- [Extended Attestation Flowchart](#extended-attestation-flowchart)
-- [Regular Attestation Flowchart](#regular-attestation-flowchart)
-- [Building](#building)
-  - [Ubuntu Dependencies](#ubuntu-dependencies)
-  - [RHEL and its compatible distributions dependencies](#rhel-and-its-compatible-distributions-dependencies)
-  - [openSUSE and its compatible distributions dependencies](#opensuse-and-its-compatible-distributions-dependencies)
-  - [Building for Azure Confidential VMs](#building-for-azure-confidential-vms)
-- [Reporting Bugs](#reporting-bugs)
+- **Attestation**: Request attestation reports from the AMD Secure Processor.
+- **Certificate management**:Get cached certificates from the hypervisor,
+  or fetch certificates from the AMD Key Distribution Service (KDS).
+- **Verification**: Verify certificate chains and attestation report.
+- **Derived key generation**: Request derived keys from the AMD-SP.
+- **Pre-attestation**: Calculate expected/reference values of launch
+  measurements, OVMF hashes, ID blocks, and key digests for use in
+  confidential VM provisioning.
 
-## Usage
+## Basic Usage
 
-### 1. `help`
-
-Every `snpguest` (sub)command comes with a `--help` option for a description on its use. 
-
-**Usage**
-```bash
-snpguest --help
+```sh
+snpguest [GLOBAL_OPTIONS] [COMMAND] [COMMAND_ARGS] [SUBCOMMAND] [SUBCOMMAND_ARGS]
 ```
 
-### 2. `certificates` 
-
-Requests the VEK certificate chain (ARK, ASK/ASVK and VCEK/VLEK) from host memory (requests extended-config). The user needs to specify the certificate encoding to store the certificates in (PEM or DER). Currently, only PEM and DER encodings are supported. All certificates will be in the same encoding. The user also needs to provide the path to the directory where the certificates will be stored. If certificates already exist in the provided directory, they will be overwritten.
-
-**Usage**
-```bash
-snpguest certificates $ENCODING $CERTS_DIR
-```
-
-**Arguments**
-
-- `$ENCODING` : Specifies the certificate encoding to store the certificates in (PEM or DER).
-
-- `$CERTS_DIR` : Specifies the directory to store the certificates in. This is required only when requesting an extended attestation report.
-
-**Example**
-```bash
-snpguest certificates pem ./certs
-```
-
-### 3. `display` 
-
-Displays files in human readable form. 
-
-**Usage**
-```bash
-snpguest display <SUBCOMMAND>
-```
-
-**Subcommands**
-
-1. `report`
-
-    When used for displaying a report, it prints the attestation report contents into the terminal. The user has to provide the path of the stored attestation report to display.
-
-    **Usage**
-    ```bash
-    snpguest display report $ATT_REPORT_PATH
-    ```
-
-    **Argument**
-
-    - `$ATT_REPORT_PATH` : Specifies the path of the stored attestation report to display.
-
-    **Example**
-    ```bash
-    snpguest display report attestation-report.bin
-    ```
-
-2. `key`
-
-    When used for displaying the fetched derived key's contents, it prints the derived key in hex format into the terminal. The user has to provide the path of a stored derived key to display.
-
-    **Usage**
-
-    ```bash
-    snpguest display key $KEY_PATH
-    ```
-    **Argument**
-
-    - `$KEY_PATH` : Specifies the path of the stored derived key to display.
-
-    **Example**
-    ```bash
-    snpguest display key derived-key.bin
-    ```
-
-### 4. `fetch`
-
-Command to Requests certificates from the KDS.
-
-**Usage**
-```bash
-snpguest fetch <SUBCOMMAND>
-```
-
-**Subcommands**
-1. `ca`
-
-    Requests the certificate authority chain (ARK & ASK/ASVK) from the KDS. The user needs to specify the certificate encoding to store the certificates in (PEM or DER). Currently, only PEM and DER encodings are supported. Both certificates will be in the same encoding. The user must specify their host processor model. The user also needs to provide the path to the directory where the certificates will be stored. If the certificates already exist in the provided directory, they will be overwritten. The `--endorser` argument specifies the type of attestation signing key (defaults to VCEK).
-
-    **Usage**
-    ```bash
-    # Fetch CA chain of the user-provided processor model
-    snpguest fetch ca $ENCODING $CERTS_DIR $PROCESSOR_MODEL --endorser $ENDORSER
-    # Fetch CA chain of the processor-model written in the attestation report
-    snpguest fetch ca $ENCODING $CERTS_DIR --report $ATT_REPORT_PATH --endorser $ENDORSER
-    ```
-    
-    **Arguments**
-    | Argument | Description | Default |
-    | :--      | :--        | :--    |
-    | `$ENCODING` | Specifies the certificate encoding to store the certificates in (PEM or DER). | required |
-    | `$CERTS_DIR` | Specifies the directory to store the certificates in. | required |
-    | `$PROCESSOR_MODEL` | Specifies the host processor model (conflict with `$ATT_REPORT_PATH`). | required |
-    | `-r, --report $ATT_REPORT_PATH` | Specifies the attestation report to detect the host processor model (conflict with `$PROCESSOR_MODEL`) | — |
-    | `-e, --endorser $ENDORSER` | Specifies the endorser type, possible values: "vcek", "vlek". | "vcek" |
-
-    **Example**
-    ```bash
-    snpguest fetch ca der ./certs-kds milan -e vlek
-    ```
-    ```bash
-    snpguest fetch ca pem ./certs-kds -r attestation-report.bin -e vcek
-    ```
-
-2. `vcek`
-
-    Requests the VCEK certificate from the KDS. The user needs to specify the certificate encoding to store the certificate in (PEM or DER). Currently, only PEM and DER encodings are supported. The user must specify their host processor model. The user also needs to provide the path to the directory where the VCEK will be stored and the path to a stored attestation report that will be used to request the VCEK. If the certificate already exists in the provided directory, it will be overwritten.
-
-    **Usage**
-    ```bash
-    snpguest fetch vcek $ENCODING $CERTS_DIR $ATT_REPORT_PATH --processor-model $PROCESSOR_MODEL
-    ```
-
-    **Arguments**
-    | Argument | Description | Default |
-    | :--      | :--        | :--    |
-    | `$ENCODING` | Specifies the certificate encoding to store the certificates in (PEM or DER). | required |
-    | `$CERTS_DIR` | Specifies the directory to store the certificates in. | required |
-    | `$ATT_REPORT_PATH` | Specifies the path of the stored attestation report. | required |
-    | `-p, --processor-model $PROCESSOR_MODEL` | Specifies the host processor model. | — |
-
-    **Example**
-    ```bash
-    snpguest fetch vcek pem ./certs-kds attestation-report.bin
-    ```
-
-3. `crl`
-
-    Requests the Certificate Revocation List (CRL) from the KDS. It takes the same set of arguments as `snpguest fetch ca`. The user needs to specify the encoding to store the CRL in (PEM or DER). Currently, only PEM and DER encodings are supported. The user must specify their host processor model. The user also needs to provide the path to the directory where the CRL will be stored. If the CRL already exists in the provided directory, it will be overwritten. The `--endorser` argument specifies the type of attestation signing key (defaults to VCEK).
-
-    **Usage**
-    ```bash
-    # Fetch CRL of the user-provided processor model
-    snpguest fetch crl $ENCODING $CERTS_DIR $PROCESSOR_MODEL --endorser $ENDORSER
-    # Fetch CRL of the processor-model written in the attestation report
-    snpguest fetch crl $ENCODING $CERTS_DIR --report $ATT_REPORT_PATH --endorser $ENDORSER
-    ```
-    
-    **Arguments**
-    | Argument | Description | Default |
-    | :--      | :--        | :--    |
-    | `$ENCODING` | Specifies the encoding to store the CRL in (PEM or DER). | required |
-    | `$CERTS_DIR` | Specifies the directory to store the CRL in. | required |
-    | `$PROCESSOR_MODEL` | Specifies the host processor model (conflict with `--report`). | required |
-    | `-r, --report $ATT_REPORT_PATH` | Specifies the attestation report to detect the host processor model (conflict with `$PROCESSOR_MODEL`) | — |
-    | `-e, --endorser $ENDORSER` | Specifies the endorser type, possible values: "vcek", "vlek". | "vcek" |
-
-    Example
-    ```bash
-    snpguest fetch crl der ./certs-kds milan -e vlek
-    ```
-    ```bash
-    snpguest fetch crl pem ./certs-kds -r attestation-report.bin -e vcek
-    ```
-
-### 5. `key` 
-
-Creates the derived key based on input parameters and stores it. `$KEY_PATH` is the path to store the derived key. `$ROOT_KEY_SELECT` is the root key from which to derive the key (either "vcek" or "vmrk"). The `--guest_field_select` option specifies which Guest Field Select bits to enable as a 64-bit integer. Only the least-significant 6 bits (Message Version 1) or 7 bits (Message Version 2) are currently defined. Each of the bits from *right to left* correspond to Guest Policy, Image ID, Family ID, Measurement, SVN and TCB Version, Launch Mitigation Vector, respectively. For each bit, 0 denotes off, and 1 denotes on. The `--guest_svn` option specifies the guest SVN to mix into the key, the `--tcb_version` option specifies the TCB version to mix into the derived key, and the `--launch_mit_vector` option specifies the launch mitigation vector value to mix into the derived key. The `--vmpl` option specifies the VMPL level the Guest is running on and defaults to 1.
-
-**Usage**
-```bash
-snpguest key $KEY_PATH $ROOT_KEY_SELECT [-v, --vmpl] [-g, --guest_field_select] [-s, --guest_svn] [-t, --tcb_version]
-```
-
-**Arguments**
-| Argument | Description | Default |
-| :--      | :--        | :--    |
-| `$KEY_PATH` | The path to store the derived key. | required |
-| `$ROOT_KEY_SELECT` | is the root key from which to derive the key (either "vcek" or "vmrk"). | required |
-| `-v, --vmpl $VMPL` | option specifies the VMPL level the Guest is running on. | 1 |
-| `-g, --guest_field_select $GFS` | option specifies which Guest Field Select bits to enable as a 64-bit integer (decimal, prefixed hex or prefixed bin). | 0 |
-| `-s, --guest_svn $GSVN` | option specifies the guest SVN to mix into the key (decimal, prefixed hex or prefixed bin). | 0 |
-| `-t, --tcb_version $TCBV` | option specifies the TCB version to mix into the derived key (decimal, prefixed hex or prefixed bin). | 0 |
-| `-l, --launch_mit_vector $LMV` | option specifies the launch mitigation vector value to mix into the derived key (decimal, prefixed hex or prefixed bin). Only available for `MSG_KEY_REQ` message version ≥ 2. | — |
-
-**Guest Field Select**
-
-| Bit      | Field             | Note |
-| :--      | :--               | :--  |
-| 63:7     | (Reserved)        | Currently not supported. |
-| 6 (MSB)  | Launch MIT Vector | Set to 0 if not specified; supported for `MSG_KEY_REQ` message version ≥ 2. |
-| 5        | TCB Version       |      |
-| 4        | SVN               |      |
-| 3        | Measurement       |      |
-| 2        | Family ID         |      |
-| 1        | Image ID          |      |
-| 0 (LSB)  | Guest Policy      |      |
-
-For example, all of
-- `--guest_field_select 49`
-- `--guest_field_select 0x31`
-- `--guest_field_select 0b110001`
-
-denote the following specification:
-```
-Guest Policy:On (1), 
-Image ID:Off (0), 
-Family ID: Off (0), 
-Measurement: Off (0), 
-SVN:On (1), 
-TCB Version:On (1),
-Launch MIT Vector: Off (none).
-```
-
-**Example**
-```bash
-# Creating and storing a derived key
-snpguest key derived-key.bin vcek --guest_field_select 0b110001 --guest_svn 2 --tcb_version 1 --vmpl 3
-```
-
-### 6. `report` 
-
-Requests an attestation report from the host and writes it to a file with the provided request data and VMPL. The attestation report is written in binary format to the specified report path. The user can pass 64 bytes of data in any file format into `$REQUEST_FILE` to request the attestation report. This data will be bound to the REPORT_DATA field of the attestation report. The `--random` flag can be used to generate and use random data for the request, which will be written into `$REQUEST_FILE`. For Microsoft Azure Confidential VM, the `--platform` flag is required to get an attestation report from the vTPM. With this flag, the request data provided by the hypervisor will be written into the `$REQUEST_FILE`. `VMPL` is an optional parameter that defaults to 1.
-
-**Usage**
-```bash
-snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] [-r, --random] [-p, --platform]
-```
-
-**Arguments**
-| Argument | Description | Default |
-| :--      | :--        | :--    |
-| `$ATT_REPORT_PATH` | Specifies the path where the attestation report would be stored. | required |
-| `$REQUEST_FILE` | Specifies the path to the 64-byte request file. <br>• With `-r` flag, 64 random bytes will be written. <br>• With `-p` flag, writes 64 bytes provided by the hypervisor will be written. <br>• Without flags, the existing file contents are read as-is. | required |
-| `-v, --vmpl $VMPL` | option specifies the VMPL level the Guest is running on.| 1 |
-| `-r, --random` | Generate 64 random bytes of data for the report request. | false |
-| `-p, --platform` | Fetch an attestation report from the vTPM NV index (Only available for Azure CVMs). | false |
-
-**Example**
-```bash
-# Requesting Attestation Report with user-generated data
-snpguest report attestation-report.bin request-file.bin
-# Requesting Attestation Report using random data
-snpguest report attestation-report.bin random-request-file.bin --random
-# Get Pregenerated Attestation Report and Request Data from vTPM
-snpguest report attestation-report.bin platform-request-file.bin --platform
-```
-
-### 7. `verify` 
-
-Verifies certificates and the attestation report.
-
-**Usage**
-```bash
-snpguest verify <SUBCOMMAND>
-```
-
-**Subcommands**
-1. `certs`
-
-    Verifies that the provided certificate chain has been properly signed by each certificate. The user needs to provide a directory where all three certificates (ARK, ASK/ASVK and VCEK/VLEK) are stored. An error will be raised if any of the certificates fail verification.
-
-    **Usage**
-    ```bash
-    snpguest verify certs $CERTS_DIR
-    ```
-    **Argument**
-
-    - `$CERTS_DIR` : Specifies the directory where the certificates are stored in. 
-
-    **Example**
-    ```bash
-    snpguest verify certs ./certs
-    ```
-
-2. `attestation`
-
-    Verifies the contents of the Attestation Report using the VCEK/VLEK certificate. The user needs to provide the path to the directory containing the VCEK/VLEK certificate and the path to a stored attestation report to be verified. An error will be raised if the attestation verification fails at any point. The user can use the `-t, --tcb` flag to only validate the TCB contents of the report and the `-s, --signature` flag to only validate the report's signature.
-
-    **Usage**
-    ```bash
-    snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [-t, --tcb] [-s, --signature] [-m, --measurement] [-d, --host-data] [-r, --report-data]
-    ```
-    **Arguments**
-
-    - `$CERTS_DIR` : Specifies the directory where the certificates are stored in. 
-
-    - `$ATT_REPORT_PATH` : Specifies the path of the stored attestation report.
-
-    **Options**
-
-    - `-t, --tcb`: Verify the Reported TCB section of the report only.
-    - `-s, --signature`: Verify the signature of the report only.
-    - `-m, --measurement`: Verify the measurement from the attestation report.
-    - `-d, --host-data`: Verify the host-data from the attestation report.
-    - `-r, --report-data`: Verify the report-data from the attestation report. 
-
-    **Example**
-    ```bash
-    # Verify Attestation
-    snpguest verify attestation ./certs attestation-report.bin
-    # Verify Attestation Reported TCB only
-    snpguest verify attestation ./certs attestation-report.bin --tcb
-    # Verify Attestation Signature only
-    snpguest verify attestation ./certs attestation-report.bin --signature
-    # Verify Attestation Measurement only
-    snpguest verify attestation --measurement 0xf28aac58964258d8ae0b2e88a706fc7afd0bb524f6a291ac3eedeccb73f89d7cfcf2e4fb6045e7d5201e41d1726afa02 /home/amd/certs /home/amd/report.bin
-    # Verify Attestation host-data only
-    snpguest verify attestation --host-data 0x7e4a3f9c1b82a056d39f0d44e5c8a7b1f02394de6b58ac0d7e3c11af0042bd59 /home/amd/certs /home/amd/report.bin
-    # Verify Attestation report-data only
-    snpguest verify attestation --report-data 0x5482c1ffe29145d47cf678f7681e3b64a89909d6cf8ec0104cfacb0b0418f005f564ad14f5c1381c99b74903a780ea340e887c9b445e9c760bf0b74115b26d45 /home/amd/certs /home/amd/report.bin 
-    ```
-
-### Global Options
-
-- **-q, --quiet**: Suppress console output.
-
-**Usage**
-```bash
-snpguest -q <SUBCOMMAND>
-```
-
-### [Extended Attestation Workflow](#extended-attestation-flowchart)
-
-**Step 1.** Request the attestation report by providing the two mandatory parameters - `$ATT_REPORT_PATH` which is the path pointing to where the user wishes to store the attestation report and `$REQUEST_FILE` which is the path pointing to where the request file used to request the attestation report is stored. The optional parameter \[`-v, --vmpl`\] specifies the vmpl level for the attestation report and is set to 1 by default. The flag \[`-r, --random`\] generates random data to be used as request data for the attestation report. Lastly, the flag \[`-p, --platform`\] obtains both the attestation report and the request data from the platform (only available for a Microsoft Azure CVM where Hyper-V guest is enabled).
+Every `snpguest` (sub)command comes with a `-h, --help` option for a
+description of its use.
+
+## Subcommands
+
+| Command | Subcommand | Description |
+|---------|------------|-------------|
+| [`ok`] | — | Quick local check if SEV-SNP is enabled in the guest environment |
+| [`report`] | — | Requests an attestation report from AMD-SP (or vTPM) |
+| [`certificates`](certs) | — | Requests certificates from the hypervisor memory via AMD-SP |
+| [`fetch`] | `ca`, `vcek`, `crl` | Fetches certificates/CRLs from AMD KDS |
+| [`verify`] | `certs`, `attestation` | Verifies certificates / attestation report |
+| [`key`] | — | Requests the derived key from AMD-SP based on input parameters |
+| [`display`] | `report`, `key` | Displays files in human-readable form |
+| [`generate`](preattestation) | `measurement`, `ovmf-hash`, `id-block`, `key-digest` | Calculates reference values |
+
+## [Extended Attestation Workflow](#extended-attestation-flowchart)
+
+![Extended attestation diagram](https://github.com/virtee/snpguest/blob/main/docs/extended.PNG?raw=true)
+
+**Step 1.** Request the attestation report by providing the two mandatory
+parameters - `$ATT_REPORT_PATH` which is the path pointing to where the
+user wishes to store the attestation report and `$REQUEST_FILE` which is
+the path pointing to where the request file used to request the attestation
+report is stored. The optional parameter `-v, --vmpl` specifies the vmpl
+level for the attestation report and is set to 1 by default. The flag
+`-r, --random` generates random data to be used as request data for the
+attestation report. Lastly, the flag `-p, --platform` obtains both the
+attestation report and the request data from the platform (only available
+for a Microsoft Azure CVM where Hyper-V guest is enabled).
 
 ```bash
-snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] [-r, --random] [-p, --platform]
+snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random] [-p, --platform]
 ```
 
-**Step 2.** Request certificates from the extended memory by providing the two mandatory parameters - `$ENCODING` which specifies whether to use PEM or DER encoding to store the certificates and $CERTS_DIR which specifies the path in the user's directory where the certificates will be saved.
+**Step 2.** Request certificates from the extended memory by providing the
+two mandatory parameters - `$ENCODING` which specifies whether to use PEM
+or DER encoding to store the certificates and $CERTS_DIR which specifies
+the path in the user's directory where the certificates will be saved.
 
 ```bash
 snpguest certificates $ENCODING $CERTS_DIR
 ```
 
-In some environments, only the VCEK/VLEK certificate can be obtained. In this case, you must follow the procedure described in [Regular Attestation Workflow](#regular-attestation-workflow) to obtain an AMD CA certificates.
+In some environments, only the VCEK/VLEK certificate can be obtained. In
+this case, you must follow the procedure described in
+[Regular Attestation Workflow](#regular-attestation-workflow) to obtain an
+AMD CA certificates.
 
-**Step 3.** Verify the certificates obtained from the extended memory by providing `$CERTS_DIR` which specifies the path in the user's directory where the certificates were saved from Step 2.
+**Step 3.** Verify the certificates obtained from the extended memory by
+providing `$CERTS_DIR` which specifies the path in the user's directory
+where the certificates were saved from Step 2.
 
 ```bash
 snpguest verify certs $CERTS_DIR
 ```
 
-**Step 4.** Verify the attestation by providing the two mandatory parameters - `$CERTS_DIR` which specifies the path in the user's directory where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which is the path pointing to the stored attestation report which the user wishes to verify. The optional parameters \[`-t, --tcb`\] is used to verify just the Reported TCB contents of the attestaion report and \[`-s, --signature`\] is used to verify just the signature of the attestaion report.
+**Step 4.** Verify the attestation by providing the two mandatory
+parameters - `$CERTS_DIR` which specifies the path in the user's directory
+where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which
+is the path pointing to the stored attestation report which the user
+wishes to verify. The optional parameters `-t, --tcb` is used to verify
+just the Reported TCB contents of the attestaion report and
+`-s, --signature` is used to verify just the signature of the attestaion
+report.
 
 ```bash
 snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [-t, --tcb] [-s, --signature]
 ```
 
-### [Regular Attestation Workflow](#regular-attestation-flowchart)
+## [Regular Attestation Workflow](#regular-attestation-flowchart)
 
-**Step 1.** Request the attestation report by providing the two mandatory parameters - `$ATT_REPORT_PATH` which is the path pointing to where the user wishes to store the attestation report and `$REQUEST_FILE` which is the path pointing to where the request file used to request the attestation report is stored. The optional parameter \[`-v, --vmpl`\] specifies the vmpl level for the attestation report and is set to 1 by default. The flag \[`-r, --random`\] generates random data to be used as request data for the attestation report. Lastly, the flag \[`-p, --platform`\] obtains both the attestation report and the request data from the platform (only available for a Microsoft Azure CVM where Hyper-V guest is enabled).
+![Regular attestation diagram](https://github.com/virtee/snpguest/blob/main/docs/regular.PNG?raw=true)
+
+**Step 1.** Request the attestation report by providing the two mandatory
+parameters - `$ATT_REPORT_PATH` which is the path pointing to where the
+user wishes to store the attestation report and `$REQUEST_FILE` which is
+the path pointing to where the request file used to request the attestation
+report is stored. The optional parameter `-v, --vmpl` specifies the vmpl
+level for the attestation report and is set to 1 by default. The flag
+`-r, --random` generates random data to be used as request data for the
+attestation report. Lastly, the flag `-p, --platform` obtains both the
+attestation report and the request data from the platform (only available
+for a Microsoft Azure CVM where Hyper-V guest is enabled).
 
 ```bash
-snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] [-r, --random] [-p, --platform]
+snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random] [-p, --platform]
 ```
 
-**Step 2.** Request AMD Root Key (ARK) and AMD SEV Key (ASK) (or AMD SEV-VLEK Key (ASVK) for VLEK) from the AMD Key Distribution Service (KDS) by providing the three mandatory parameters - `$ENCODING` which specifies whether to use PEM or DER encoding to store the certificates, `$CERTS_DIR` which specifies the path in the user's directory where the certificates will be saved, and `$PROCESSOR_MODEL` - which specifies the AMD Processor model for which the certificates are to be fetched. The optional `-e, --endorser` argument specifies the type of attestation signing key (defaults to VCEK).
+**Step 2.** Request AMD Root Key (ARK) and AMD SEV Key (ASK) (or AMD
+SEV-VLEK Key (ASVK) for VLEK) from the AMD Key Distribution Service (KDS)
+by providing the three mandatory parameters - `$ENCODING` which specifies
+whether to use PEM or DER encoding to store the certificates, `$CERTS_DIR`
+which specifies the path in the user's directory where the certificates
+will be saved, and `$PROCESSOR_MODEL` - which specifies the AMD Processor
+model for which the certificates are to be fetched. The optional
+`-e, --endorser` argument specifies the type of attestation signing key
+(defaults to VCEK).
 
 ```bash
 snpguest fetch ca $ENCODING $CERTS_DIR $PROCESSOR_MODEL [-e, --endorser] $ENDORSER
 ```
 
-**Step 3.** Request the Versioned Chip Endorsement Key (VCEK) from the AMD Key Distribution Service (KDS) by providing the three mandatory parameters - `$ENCODING` which specifies whether to use PEM or DER encoding to store the certificates, `$CERTS_DIR` which specifies the path in the user's directory where the certificates will be saved, and `$ATT_REPORT_PATH` which is the path pointing to the stored attestation report for detecting Chip ID and Reported TCB Version. The optional \[`-p, --processor-model`\] argument specifies the AMD Processor model for which the certificates are to be fetched.
+**Step 3.** Request the Versioned Chip Endorsement Key (VCEK) from the AMD
+Key Distribution Service (KDS) by providing the three mandatory
+parameters - `$ENCODING` which specifies whether to use PEM or DER
+encoding to store the certificates, `$CERTS_DIR` which specifies the path
+in the user's directory where the certificates will be saved, and
+`$ATT_REPORT_PATH` which is the path pointing to the stored attestation
+report for detecting Chip ID and Reported TCB Version. The optional
+`-p, --processor-model` argument specifies the AMD Processor model for
+which the certificates are to be fetched.
 
 ```bash
 snpguest fetch vcek $ENCODING $CERTS_DIR $ATT_REPORT_PATH [-p, --processor-model] $PROCESSOR_MODEL
 ```
 
-**Step 4.** Verify the certificates obtained by providing `$CERTS_DIR` which specifies the path in the user's directory where the certificates were saved from Step 2.
+**Step 4.** Verify the certificates obtained by providing `$CERTS_DIR`
+which specifies the path in the user's directory where the certificates
+were saved from Step 2.
 
 ```bash
 snpguest verify certs $CERTS_DIR
 ```
 
-**Step 5.** Verify the attestation by providing the two mandatory parameters - `$CERTS_DIR` which specifies the path in the user's directory where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which is the path pointing to the stored attestation report which the user wishes to verify. The optional parameters \[`-t, --tcb`\] is used to verify just the Reported TCB contents of the attestaion report and \[`-s, --signature`\] is used to verify just the signature of the attestaion report.
+**Step 5.** Verify the attestation by providing the two mandatory
+parameters - `$CERTS_DIR` which specifies the path in the user's directory
+where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which
+is the path pointing to the stored attestation report which the user
+wishes to verify. The optional parameters `-t, --tcb` is used to verify
+just the Reported TCB contents of the attestaion report and
+`-s, --signature` is used to verify just the signature of the attestaion
+report.
 
 ```bash
 snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [-t, --tcb] [-s, --signature]
 ```
 
-## Extended Attestation Flowchart
-![alt text](https://github.com/virtee/snpguest/blob/main/docs/extended.PNG?raw=true)
-## Regular Attestation Flowchart
-![alt text](https://github.com/virtee/snpguest/blob/main/docs/regular.PNG?raw=true)
+## Build
 
-## Building
-
-Some packages may need to be installed on the host system in order to build `snpguest`.
+### For Standard CVMs
 
 ```bash
-#Rust Installation
+# Build
+git clone https://github.com/virtee/snpguest
+cd snpguest
+cargo build -r
+
+# Install from the repository
+cargo install --git https://github.com/virtee/snpguest
+
+# Install from crate.io
+cargo install snpguest
+```
+
+### For Azure CVMs
+
+On Azure CVMs, all communication between the guest OS and AMD-SP is proxied
+by the OpenHCL paravisor. The native `/dev/sev-guest` interface is hidden
+from the guest OS. The user must specify the `--platform` flag to get an
+attestation report; this flag is available only in builds compiled with the
+`hyperv` feature.
+
+```bash
+# Install additional dependencies
+sudo apt update
+sudo apt install -y pkg-config libtss2-dev
+
+# Build
+git clone https://github.com/virtee/snpguest
+cd snpguest
+cargo build -r --features hyperv
+
+# Install from the repository
+cargo install --git https://github.com/virtee/snpguest --features hyperv
+
+# Install from crate.io
+cargo install snpguest --features hyperv
+```
+
+### Build Dependencies
+
+Some packages may need to be installed on the guest system in order to
+build `snpguest`.
+
+#### Rust
+
+```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
-
-#Building snpguest after cloning
-cargo build -r
 ```
-### Ubuntu Dependencies
+
+#### Ubuntu Dependencies
 
 ```bash
 sudo apt install build-essential
 ```
 
-### RHEL and its compatible distributions Dependencies
+#### RHEL and its compatible distributions Dependencies
 
 ```bash
 sudo dnf groupinstall "Development Tools" "Development Libraries"
 ```
 
-### openSUSE and its compatible distributions Dependencies
+#### openSUSE and its compatible distributions Dependencies
 
 ```bash
 sudo zypper in -t pattern "devel_basis"
 ```
 
-### Building for Azure Confidential VMs
-On Azure CVMs with AMD SEV-SNP, the paravisor fetches the report from AMD-SP once at VM boot time, and stores it in the vTPM NV index. The native `/dev/sev-guest` interface is hidden from the guest OS, so the guest OS must retrieve the report from the vTPM NV index using the `--platform` flag, which is available only in builds compiled with the `hyperv` feature.
+### Load sev-guest module
+
+In some guest environments, the device `/dev/sev-guest` does not created
+by default. In such cases, make sure that the kernel supports SEV-SNP,
+then load the sev-guest module.
 
 ```bash
-git clone https://github.com/virtee/snpguest
-cd ./snpguest
-cargo build -r --features hyperv
+modprobe sev-guest
+ls -l /dev/sev-guest
 ```
 
 ## Reporting Bugs
 
 Please report all bugs to the [Github snpguest](https://github.com/virtee/snpguest/issues) repository.
+
+<!-- cargo-rdme end -->

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -1,5 +1,43 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains code related to managing certificates. It defines a structure for managing certificate paths (`CertPaths`) and functions for obtaining extended certificates from the AMD Secure Processor.
+
+//! Requests certificates from Host.
+//!
+//! This module provides the `certificate` subcommand which retrieves certificates
+//! cached in hypervisor memory via the AMD Secure Processor (`SNP_GET_EXT_REPORT` ioctl),
+//! converting certificate formats (PEM/DER).
+//!
+//! ## `certificates`
+//!
+//! ```bash
+//! snpguest report $ATT_REPORT_PATH $REQUEST_FILE [OPTIONS]
+//! ```
+//!
+//! The output depends on which certificates are cached in the hypervisor memory.
+//! Before executing this command, the host (platform owner) must fetch certificates
+//! from AMD KDS and load them into the extended configuration.
+//!
+//! ## Note
+//!
+//! In principle, the host can cache any certificate. However, in practice, it
+//! typically caches only the leaf certificate (VCEK or VLEK) or the entire
+//! certificate chain.
+//!
+//! Note that this feature is *not* supported in the current upstream kernels.
+//! Actual behavior also depends on the kernel version. For example, behavior
+//! when executed without loading certificates.
+//!
+//! ## Arguments
+//!
+//! | Argument | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ENCODING` | The certificate encoding to store the certificates in (PEM or DER). All certificates will be in the same encoding. | *required* |
+//! | `$CERTS_DIR` | The directory to store the certificates in. If certificates already exist in the provided directory, they will be overwritten. | *required* |
+//!
+//! ## Example
+//!
+//! ```bash
+//! snpguest certificates pem ./certs
+//! ```
 
 use crate::fetch::Endorsement;
 
@@ -17,18 +55,25 @@ use sev::{
     firmware::{guest::Firmware, host::CertType},
 };
 
+/// Paths to the three certificates that form an SNP certificate chain:
+/// ARK (AMD Root Key), ASK (AMD SEV Key) or ASVK (AMD SEV-VLEK Key),
+/// and VCEK (Versioned Chip Endorsement Key) or VLEK (Versioned Loaded Endorsement Key).
 pub struct CertPaths {
+    /// Path to the AMD Root Key certificate.
     pub ark_path: PathBuf,
+    /// Path to the AMD SEV Key (or ASVK for VLEK chains) certificate.
     pub ask_path: PathBuf,
+    /// Path to the VCEK or VLEK certificate.
     pub vek_path: PathBuf,
 }
 
+/// Supported certificate encoding formats.
 #[derive(ValueEnum, Clone, Copy)]
 pub enum CertFormat {
-    /// Certificates are encoded in PEM format.
+    /// PEM (Privacy-Enhanced Mail) encoding.
     Pem,
 
-    /// Certificates are encoded in DER format.
+    /// DER (Distinguished Encoding Rules) binary encoding.
     Der,
 }
 
@@ -52,7 +97,10 @@ impl FromStr for CertFormat {
     }
 }
 
-// Function that will convert a cert path into a snp Certificate
+/// Read a certificate file and convert it into an SNP [`Certificate`].
+///
+/// If `cert_path` is empty, falls back to looking in `./certs/` for
+/// `{cert_type}.pem` or `{cert_type}.der`.
 pub fn convert_path_to_cert(
     cert_path: &PathBuf,
     cert_type: &str,
@@ -88,7 +136,7 @@ pub fn convert_path_to_cert(
     Ok(Certificate::from_bytes(&buf)?)
 }
 
-// Tryfrom function that takes in 3 certificate paths returns a snp Certificate Chain
+/// Build an SNP [`Chain`] from three certificate file paths (ARK, ASK/ASVK, VCEK/VLEK).
 impl TryFrom<CertPaths> for Chain {
     type Error = anyhow::Error;
     fn try_from(content: CertPaths) -> Result<Self, Self::Error> {
@@ -117,7 +165,11 @@ impl TryFrom<CertPaths> for Chain {
     }
 }
 
-// Function used to write provided cert into desired directory.
+/// Write a certificate to a file in the specified encoding format.
+///
+/// The filename is derived from the certificate type and encoding
+/// (e.g., `vcek.pem`, `ark.der`). For VLEK endorsement with an ASK
+/// cert type, the file is named `asvk`.
 pub fn write_cert(
     path: &Path,
     cert_type: &CertType,
@@ -164,17 +216,26 @@ pub fn write_cert(
     Ok(())
 }
 
+/// CLI arguments for the `certificates` subcommand.
+///
+/// Requests certificates from the hypervisor extended memory via the AMD
+/// Secure Processor and stores them in the specified directory.
 #[derive(Parser)]
 pub struct CertificatesArgs {
-    /// Specify encoding to use for certificates.
+    /// Certificate encoding format (PEM or DER).
     #[arg(value_name = "encoding", required = true, ignore_case = true)]
     pub encoding: CertFormat,
 
-    /// Directory to store certificates in. Required if requesting an extended-report.
+    /// Directory to store the certificates in. Created if it does not exist.
     #[arg(value_name = "certs-dir", required = true)]
     pub certs_dir: PathBuf,
 }
 
+/// Request extended certificates from the AMD Secure Processor and write them to disk.
+///
+/// Uses `SNP_GET_EXT_REPORT` to obtain certificates cached in the hypervisor
+/// extended memory. Each certificate is written to the specified directory in the
+/// chosen encoding format.
 pub fn get_ext_certs(args: CertificatesArgs) -> Result<()> {
     let mut sev_fw: Firmware = Firmware::open().context("failed to open SEV firmware device.")?;
 

--- a/src/clparser/mod.rs
+++ b/src/clparser/mod.rs
@@ -1,8 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains custom u32/u64 parsers for supporting decimal, hexadecimal and binary formats.
+
+//! Custom integer parsers for CLI arguments supporting multiple radix formats.
+//!
+//! Provides a clap-compatible value parser that accepts integers in:
+//! - Decimal (e.g., `63`)
+//! - Hexadecimal with `0x` prefix (e.g., `0x3f`)
+//! - Binary with `0b` prefix (e.g., `0b111111`)
 
 use std::num::ParseIntError;
 
+/// Parse an integer string with automatic radix detection.
+///
+/// Supported formats:
+/// - `0x...` — hexadecimal
+/// - `0b...` — binary
+/// - anything else — decimal
 pub fn parse_int_auto_radix<T>(s: &str) -> Result<T, ParseIntError>
 where
     T: FromStrRadix,
@@ -16,7 +28,11 @@ where
     }
 }
 
+/// Trait for parsing integers from a string with a given radix.
+///
+/// Implemented for [`u32`] and [`u64`].
 pub trait FromStrRadix: Sized {
+    /// Parse `src` as an integer in the given `radix` (2, 10, or 16).
     fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError>;
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,18 +1,67 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains the subcommands for displaying attestation reports and derived keys.
+
+//! Prints attestation reports andderived keys.
+//!
+//! This module provides the following subcommands, which display artifacts
+//! in human-readable form.
+//!
+//! - `display report` — Print an attestation report's contents to the terminal.
+//! - `display key` — Print a derived key in hex format to the terminal.
+//!
+//! ## `display report`
+//!
+//! ```bash
+//! snpguest display report $ATT_REPORT_PATH
+//! ```
+//!
+//! Prints the attestation report contents into the terminal.
+//!
+//! ### Arguments
+//!
+//! | Argument | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ATT_REPORT_PATH` | The path of the stored attestation report to display. | *required* |
+//!
+//! ### Example
+//!
+//! ```bash
+//! snpguest display report report.bin
+//! ```
+//!
+//! ## `display key`
+//!
+//! ```bash
+//! snpguest display key $KEY_PATH
+//! ```
+//!
+//! Prints the derived key in hex format into the terminal.
+//!
+//! ### Arguments
+//!
+//! | Argument | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$KEY_PATH` | The path of the stored derived key to display. | *required* |
+//!
+//! ### Example
+//!
+//! ```bash
+//! snpguest display key derived-key.bin
+//! ```
 
 use super::*;
 use std::path::PathBuf;
 
+/// Subcommands for displaying attestation data in human-readable form.
 #[derive(Subcommand)]
 pub enum DisplayCmd {
-    /// Display an attestation report in console.
+    /// Print the contents of an attestation report to the terminal.
     Report(report_display::Args),
 
-    /// Display the derived key in console.
+    /// Print a derived key in hex format to the terminal.
     Key(key_display::Args),
 }
 
+/// Dispatch to the appropriate display subcommand handler.
 pub fn cmd(cmd: DisplayCmd, quiet: bool) -> Result<()> {
     match cmd {
         DisplayCmd::Report(args) => report_display::display_attestation_report(args, quiet),
@@ -22,14 +71,15 @@ pub fn cmd(cmd: DisplayCmd, quiet: bool) -> Result<()> {
 mod report_display {
     use super::*;
 
+    /// CLI arguments for `display report`.
     #[derive(Parser)]
     pub struct Args {
-        /// Path to attestation report to display.
+        /// Path to the attestation report file to display.
         #[arg(value_name = "att-report-path", required = true)]
         pub att_report_path: PathBuf,
     }
 
-    // Print attestation report in console
+    /// Read and print an attestation report to the console.
     pub fn display_attestation_report(args: Args, quiet: bool) -> Result<()> {
         let att_report = report::read_report(args.att_report_path)
             .context("Could not open attestation report")?;
@@ -45,14 +95,15 @@ mod report_display {
 mod key_display {
     use super::*;
 
+    /// CLI arguments for `display key`.
     #[derive(Parser)]
     pub struct Args {
-        /// Path of key to be displayed.
+        /// Path to the derived key file to display.
         #[arg(value_name = "key-path", required = true)]
         pub key_path: PathBuf,
     }
 
-    // Print derived key in console
+    /// Read and print a derived key in hex format (16 bytes per line).
     pub fn display_derived_key(args: Args, quiet: bool) -> Result<()> {
         let key_report = key::read_key(args.key_path).context("Could not open key")?;
 
@@ -62,7 +113,6 @@ mod key_display {
                 if (i % 16) == 0 {
                     keydata.push('\n');
                 }
-                //Displaying key in Hex format
                 keydata.push_str(&format!("{byte:02x} "));
             }
             keydata.push('\n');

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,5 +1,134 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains subcommands for fetching various types of certificates from the AMD Secure Processor.
+
+//! Fetches certificates and CRL from AMD KDS.
+//!
+//! This module provides the following subcommands, which request certificates
+//! and CRLs from the AMD Key Distribution Service (KDS).
+//!
+//! - `fetch ca` — Fetch the AMD Root Key (ARK) and AMD SEV Key (ASK/ASVK)
+//! - `fetch vcek` — Fetch the Versioned Chip Endorsement Key (VCEK)
+//! - `fetch crl` — Fetch the Certificate Revocation List (CRL)
+//!
+//! Certificates are fetched over HTTPS from `kdsintf.amd.com` and written
+//! to disk in the user-specified encoding (PEM or DER).
+//!
+//! ## `fetch ca`
+//!
+//! ```bash
+//! snpguest fetch ca $ENCODING $CERTS_DIR $PROCESSOR_MODEL [OPTIONS]
+//! ```
+//!
+//! Fetches the AMD root CA certificate (ARK) and the AMD intermediate certificate
+//! (ASK for VCEK or ASVK for VLEK) from the AMD KDS, and writes them in PEM or
+//! DER format.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ENCODING` | The certificate encoding to store the certificates in (PEM or DER). | *required* |
+//! | `$CERTS_DIR` | The directory to store the certificates in. | *required* |
+//! | `$PROCESSOR_MODEL` | The host processor model (`milan`, `genoa`, `bergano`, `sienna`, `turin`). (Conflicts with `--report`) | required |
+//! | `-r, --report` | Path to the attestation report to detect the host processor model. (Conflicts with `$PROCESSOR_MODEL`) | - |
+//! | `-e, --endorser` | The endorser type (`vcek` or `vlek`). | `vcek` |
+//!
+//! The user must specify either the host processor model `$PROCESSOR_MODEL`
+//! (`milan`, `genoa`, `bergano`, `sienna`, `turin`) or the path to an attestation
+//! report using the `-r, --report` option. When the report is provided, the
+//! command attempts to infer the host processor model from the report.
+//! Autodetection succeeds only under the following conditions:
+//!
+//! 1. **Report Version 3 or later**
+//!    - both `CPU_FAM_ID` and `CPU_MOD_ID` are present (i.e. not missing)
+//! 2. **Report Version 2**
+//!    - the host processor model is Turin
+//!    - the `CHIP_ID` is not masked, i.e. `MASK_CHIP_ID` is zero-filled
+//!
+//! In the latter case, automatic detection is based on heuristics: whereas
+//! pre-Turin's `CHIP_ID` utilises the full 64 bytes, Turin's `CHIP_ID` uses
+//! only the first 8 bytes. This heuristics may not remain valid for future
+//! processors.
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Fetch CA cert chain in DER encoding for with milan with VLEK
+//! # ark.der and asvk.der will be stored in ./certs
+//! snpguest fetch ca der ./certs milan -e vlek
+//!
+//! # Fetch CA cert chain in PEM encoding associated with V3+ report and VCEK
+//! # ark.pem and ask.pem will be stored in ./certs
+//! snpguest fetch ca pem ./certs -r report.bin -e vcek
+//! ```
+//!
+//! ## `fetch vcek`
+//!
+//! ```bash
+//! snpguest fetch vcek $ENCODING $CERTS_DIR $ATT_REPORT_PATH [OPTIONS]
+//! ```
+//!
+//! Fetches the VCEK certificate from the AMD KDS, and write it in PEM or DER
+//! format.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ENCODING` | The certificate encoding to store the certificates in (PEM or DER). | *required* |
+//! | `$CERTS_DIR` | The directory to store the certificates in. | *required* |
+//! | `$ATT_REPORT_PATH` | The path of the stored attestation report. | *required* |
+//! | `-p, --processor-model` | The host processor model (`milan`, `genoa`, `bergano`, `sienna`, `turin`). If the report is *older than version 3*, this option must be specified. | - |
+//!
+//! The user must provide the path to an attestation report `$ATT_REPORT_PATH`
+//! to get the REPORTED_TCB and CHIP_ID.
+//!
+//! The user can specify the host processor model using the `--processor-model`
+//! option. If the processor model is not specified, the command attempts to infer
+//! the host processor model from the report contents. Autodetection follows the
+//! same rules and limitations as the `ca` subcommand.
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Fetch VCEK certificate in PEM encoding associated with V3+ report from AMD KDS
+//! # vcek.pem will be stored in ./certs
+//! snpguest fetch vcek pem ./certs report.bin
+//!
+//! # If the report is older than V3, manually specify the processor model
+//! snpguest fetch vcek pem ./certs report.bin -p milan
+//! ```
+//!
+//! ## `fetch crl`
+//!
+//! ```bash
+//! snpguest fetch crl $ENCODING $CERTS_DIR $PROCESSOR_MODEL [OPTIONS]
+//! ```
+//!
+//! Fetches the Certificate Revocation List (CRL) from the AMD KDS, and writes
+//! it in PEM or DER format. This subcommand has completely the same API as the
+//! `ca` subcommand.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ENCODING` | The CRL encoding to store the CRL in (PEM or DER). | *required* |
+//! | `$CERTS_DIR` | The directory to store the CRL in. | *required* |
+//! | `$PROCESSOR_MODEL` | The host processor model (`milan`, `genoa`, `bergano`, `sienna`, `turin`). (Conflicts with `--report`) | required |
+//! | `-r, --report` | Path to the attestation report to detect the host processor model. (Conflict with `$PROCESSOR_MODEL`) | - |
+//! | `-e, --endorser` | The endorser type (`vcek` or `vlek`). | `vcek` |
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Fetch CRL in DER encoding for milan with VLEK
+//! # crl.der will be stored in ./certs
+//! snpguest fetch crl der ./certs milan -e vlek
+//!
+//! # Fetch CRL in PEM encoding associated with V3+ report and VCEK
+//! # ark.pem and ask.pem will be stored in ./certs
+//! snpguest fetch crl pem ./certs -r report.bin -e vcek
+//! ```
 
 use super::*;
 
@@ -16,24 +145,26 @@ use sev::{
 
 use certs::{write_cert, CertFormat};
 
+/// Subcommands for fetching certificates and CRLs from the AMD KDS.
 #[derive(Subcommand)]
 pub enum FetchCmd {
-    /// Fetch the certificate authority (ARK & ASK) from the KDS.
+    /// Fetch the AMD Root Key (ARK) and AMD SEV Key (ASK/ASVK) from the KDS.
     CA(cert_authority::Args),
 
-    /// Fetch the VCEK from the KDS.
+    /// Fetch the Versioned Chip Endorsement Key (VCEK) from the KDS.
     Vcek(vcek::Args),
 
-    /// Fetch the CRL from the KDS.
+    /// Fetch the Certificate Revocation List (CRL) from the KDS.
     Crl(crl::Args),
 }
 
+/// The type of attestation signing key (endorsement key).
 #[derive(ValueEnum, Debug, Clone, PartialEq, Eq)]
 pub enum Endorsement {
-    /// Versioned Chip Endorsement Key
+    /// Versioned Chip Endorsement Key — unique per chip, derived from fused secrets.
     Vcek,
 
-    /// Versioned Loaded Endorsement Key
+    /// Versioned Loaded Endorsement Key — provisioned by the platform owner.
     Vlek,
 }
 
@@ -57,21 +188,25 @@ impl FromStr for Endorsement {
         }
     }
 }
+
+/// AMD EPYC processor model used to select the correct KDS endpoint.
+///
+/// Bergamo and Siena share the same KDS endpoint as Genoa.
 #[derive(ValueEnum, Debug, Clone, PartialEq, Eq)]
 pub enum ProcType {
-    /// 3rd Gen AMD EPYC Processor (Standard)
+    /// 3rd Gen AMD EPYC Processor (Standard).
     Milan,
 
-    /// 4th Gen AMD EPYC Processor (Standard)
+    /// 4th Gen AMD EPYC Processor (Standard).
     Genoa,
 
-    /// 4th Gen AMD EPYC Processor (Performance)
+    /// 4th Gen AMD EPYC Processor (Performance). Uses the Genoa KDS endpoint.
     Bergamo,
 
-    /// 4th Gen AMD EPYC Processor (Edge)
+    /// 4th Gen AMD EPYC Processor (Edge). Uses the Genoa KDS endpoint.
     Siena,
 
-    /// 5th Gen AMD EPYC Processor (Standard)
+    /// 5th Gen AMD EPYC Processor (Standard).
     Turin,
 }
 
@@ -111,6 +246,11 @@ impl fmt::Display for ProcType {
     }
 }
 
+/// Determine the processor model from an attestation report.
+///
+/// For report version 3+, uses the CPU family and model IDs. For version 2,
+/// attempts heuristic detection based on the CHIP_ID field (only succeeds
+/// for Turin, where CHIP_ID uses only the first 8 bytes).
 pub fn get_processor_model(att_report: AttestationReport) -> Result<ProcType> {
     if att_report.version < 3 {
         if [0u8; 64] == att_report.chip_id {
@@ -151,6 +291,7 @@ pub fn get_processor_model(att_report: AttestationReport) -> Result<ProcType> {
     }
 }
 
+/// Dispatch to the appropriate fetch subcommand handler.
 pub fn cmd(cmd: FetchCmd) -> Result<()> {
     match cmd {
         FetchCmd::CA(args) => cert_authority::fetch_ca(args),
@@ -163,17 +304,22 @@ mod cert_authority {
     use super::*;
     use reqwest::StatusCode;
 
+    /// CLI arguments for `fetch ca`.
+    ///
+    /// Fetches the ARK and ASK (or ASVK for VLEK) from the AMD KDS.
+    /// Either `processor_model` or `att_report` must be specified (mutually exclusive).
     #[derive(Parser)]
     pub struct Args {
-        /// Specify encoding to use for certificates.
+        /// Certificate encoding format (PEM or DER).
         #[arg(value_name = "encoding", required = true, ignore_case = true)]
         pub encoding: CertFormat,
 
-        /// Directory to store the certificates in.
+        /// Directory to store the certificates in. Created if it does not exist.
         #[arg(value_name = "certs-dir", required = true)]
         pub certs_dir: PathBuf,
 
-        /// Specify the processor model for the desired certificate chain.
+        /// Host processor model (milan, genoa, bergamo, siena, turin).
+        /// Conflicts with `--report`.
         #[arg(
             value_name = "processor-model",
             required_unless_present = "att_report",
@@ -182,7 +328,9 @@ mod cert_authority {
         )]
         pub processor_model: Option<ProcType>,
 
-        /// Attestation Report to get processor model from (V3 of report needed).
+        /// Path to an attestation report to auto-detect the processor model.
+        /// Requires report version 3+, or version 2 with a Turin processor.
+        /// Conflicts with the positional `processor-model` argument.
         #[arg(
             short = 'r',
             long = "report",
@@ -192,12 +340,12 @@ mod cert_authority {
         )]
         pub att_report: Option<PathBuf>,
 
-        /// Specify which endorsement certificate chain to pull, either VCEK or VLEK.
+        /// Endorser type: VCEK (fetches ARK + ASK) or VLEK (fetches ARK + ASVK).
         #[arg(short, long, value_name = "endorser", default_value_t = Endorsement::Vcek, ignore_case = true)]
         pub endorser: Endorsement,
     }
 
-    // Function to build kds request for ca chain and return a vector with the 2 certs (ASK & ARK)
+    /// Fetch the CA certificate chain (ARK + ASK/ASVK) from the AMD KDS.
     pub fn request_ca_kds(
         processor_model: ProcType,
         endorser: &Endorsement,
@@ -230,7 +378,7 @@ mod cert_authority {
         }
     }
 
-    // Fetch the ca from the kds and write it into the certs directory
+    /// Fetch the CA certificates from the KDS and write them to the specified directory.
     pub fn fetch_ca(args: Args) -> Result<()> {
         let proc_model = if let Some(processor_model) = args.processor_model {
             processor_model
@@ -277,26 +425,30 @@ mod vcek {
 
     use super::*;
 
+    /// CLI arguments for `fetch vcek`.
+    ///
+    /// Fetches the VCEK certificate from the AMD KDS using the REPORTED_TCB
+    /// and CHIP_ID from a stored attestation report.
     #[derive(Parser)]
     pub struct Args {
-        /// Specify encoding to use for certificates.
+        /// Certificate encoding format (PEM or DER).
         #[arg(value_name = "encoding", required = true, ignore_case = true)]
         pub encoding: CertFormat,
 
-        /// Directory to store the certificates in.
+        /// Directory to store the certificate in. Created if it does not exist.
         #[arg(value_name = "certs-dir", required = true)]
         pub certs_dir: PathBuf,
 
-        /// Path to attestation report to use to request VCEK.
+        /// Path to the attestation report (used to extract CHIP_ID and REPORTED_TCB).
         #[arg(value_name = "att-report-path", required = true)]
         pub att_report: PathBuf,
 
-        /// Specify the processor model for the desired vcek.
+        /// Host processor model. If not specified, auto-detected from the report.
         #[arg(short, long, value_name = "processor-model", ignore_case = true)]
         pub processor_model: Option<ProcType>,
     }
 
-    // Function to request vcek from KDS. Return vcek in der format.
+    /// Fetch the VCEK certificate from the AMD KDS in DER format.
     pub fn request_vcek_kds(
         processor_model: ProcType,
         att_report_path: PathBuf,
@@ -372,7 +524,7 @@ mod vcek {
         }
     }
 
-    // Function to request vcek from kds and write it into file
+    /// Fetch the VCEK from the KDS and write it to the specified directory.
     pub fn fetch_vcek(args: Args) -> Result<()> {
         let proc_model = if let Some(proc_model) = args.processor_model {
             proc_model
@@ -407,17 +559,23 @@ mod crl {
     use reqwest::StatusCode;
     use std::io::Write;
 
+    /// CLI arguments for `fetch crl`.
+    ///
+    /// Fetches the Certificate Revocation List from the AMD KDS.
+    /// Has the same interface as `fetch ca`: either `processor_model` or
+    /// `att_report` must be specified (mutually exclusive).
     #[derive(Parser)]
     pub struct Args {
-        /// Specify encoding to use for the CRL.
+        /// CRL encoding format (PEM or DER).
         #[arg(value_name = "encoding", required = true, ignore_case = true)]
         pub encoding: CertFormat,
 
-        /// Directory to store the CRL in.
+        /// Directory to store the CRL in. Created if it does not exist.
         #[arg(value_name = "certs-dir", required = true)]
         pub certs_dir: PathBuf,
 
-        /// Specify the processor model for the desired CRL.
+        /// Host processor model (milan, genoa, bergamo, siena, turin).
+        /// Conflicts with `--report`.
         #[arg(
             value_name = "processor-model",
             required_unless_present = "att_report",
@@ -426,7 +584,8 @@ mod crl {
         )]
         pub processor_model: Option<ProcType>,
 
-        /// Attestation Report to get processor model from (V3 of report needed).
+        /// Path to an attestation report to auto-detect the processor model.
+        /// Conflicts with the positional `processor-model` argument.
         #[arg(
             short = 'r',
             long = "report",
@@ -436,12 +595,12 @@ mod crl {
         )]
         pub att_report: Option<PathBuf>,
 
-        /// Specify which endorsement CRL to pull, either VCEK or VLEK.
+        /// Endorser type: VCEK or VLEK.
         #[arg(short, long, value_name = "endorser", default_value_t = Endorsement::Vcek, ignore_case = true)]
         pub endorser: Endorsement,
     }
 
-    // Function to build kds request for CRL and return a CRL
+    /// Fetch the CRL from the AMD KDS in DER format.
     pub fn request_crl_kds(
         processor_model: ProcType,
         endorser: &Endorsement,
@@ -469,7 +628,7 @@ mod crl {
         }
     }
 
-    // Fetch the CRL from the kds and write it into the certs directory
+    /// Fetch the CRL from the KDS and write it to the specified directory.
     pub fn fetch_crl(args: Args) -> Result<()> {
         let proc_model = if let Some(processor_model) = args.processor_model {
             processor_model

--- a/src/hyperv/mod.rs
+++ b/src/hyperv/mod.rs
@@ -1,5 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains code related to Hyper-V integration (Hypervisor). It provides a flag (`hyperv::present`) indicating whether the SNP Guest is running within a Hyper-V guest environment.
+
+//! Hyper-V detection and vTPM-based attestation report retrieval.
+//!
+//! On Microsoft Azure Confidential VMs with SEV-SNP isolation, the native
+//! `/dev/sev-guest` interface is hidden from the guest OS by the OpenHCL
+//! paravisor. Instead, attestation reports are pre-generated at VMPL 0
+//! and stored in a vTPM NV index (`0x01400001`).
+//!
+//! This module provides:
+//! - [`present()`] — Detect whether the guest is running under Hyper-V
+//!   with SNP isolation (via CPUID checks).
+//! - [`report::get()`] — Retrieve the pre-generated attestation report
+//!   from the vTPM.
 
 use super::*;
 
@@ -28,6 +40,14 @@ const RSV2_SIZE: usize = size_of::<u32>() * 5;
 const TOTAL_SIZE: usize = RSV1_SIZE + REPORT_SIZE + RSV2_SIZE;
 const REPORT_RANGE: std::ops::Range<usize> = RSV1_SIZE..(RSV1_SIZE + REPORT_SIZE);
 
+/// Detect whether the guest is running under Hyper-V with SEV-SNP isolation.
+///
+/// Checks CPUID leaves for:
+/// 1. Hypervisor presence bit (CPUID 1, ECX bit 31)
+/// 2. "Microsoft Hv" vendor signature
+/// 3. Hyper-V isolation feature (without CPU management — indicating a
+///    hardware-isolated VM rather than a traditional VM)
+/// 4. SNP isolation type
 pub fn present() -> bool {
     let mut cpuid = unsafe { __cpuid(CPUID_PROCESSOR_INFO_AND_FEATURE_BITS) };
     if (cpuid.ecx & CPUID_FEATURE_HYPERVISOR) == 0 {
@@ -73,6 +93,7 @@ pub fn present() -> bool {
     true
 }
 
+/// vTPM-based attestation report retrieval for Hyper-V guests.
 pub mod report {
     use super::*;
 
@@ -86,8 +107,13 @@ pub mod report {
         tcti_ldr::{DeviceConfig, TctiNameConf},
     };
 
+    /// vTPM NV index where the HCL report (containing the attestation report) is stored.
     const VTPM_HCL_REPORT_NV_INDEX: u32 = 0x01400001;
 
+    /// Retrieve the pre-generated attestation report from the vTPM.
+    ///
+    /// The `vmpl` argument is ignored because the report is pre-fetched at
+    /// VMPL 0. A warning is printed if a non-zero VMPL is specified.
     pub fn get(vmpl: u32) -> Result<AttestationReport> {
         if vmpl > 0 {
             eprintln!("Warning: --vmpl argument was ignored because attestation report is pre-fetched at VMPL 0 and stored in vTPM.");
@@ -97,6 +123,7 @@ pub mod report {
         hcl_report(&bytes)
     }
 
+    /// Read the HCL report bytes from the vTPM NV index.
     fn tpm2_read() -> Result<Vec<u8>> {
         let handle = NvIndexTpmHandle::new(VTPM_HCL_REPORT_NV_INDEX)
             .context("unable to initialize TPM handle")?;
@@ -107,6 +134,10 @@ pub mod report {
             .context("unable to read non-volatile vTPM data")
     }
 
+    /// Extract the SNP attestation report from the HCL report format.
+    ///
+    /// The HCL report contains reserved fields, the attestation report
+    /// (1184 bytes), and additional reserved fields.
     fn hcl_report(bytes: &[u8]) -> Result<AttestationReport> {
         if bytes.len() < TOTAL_SIZE {
             return Err(anyhow!(

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,44 +1,128 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains code for fetching derived keys from root keys. It also includes functions for requesting and saving derived keys.
+
+//! Requests derived keys from AMD-SP.
+//!
+//! This module provides the `key` subcommand which requests derived keys from
+//! the AMD-SP via the `SNP_GUEST_REQUEST(MSG_KEY_REQ)` ioctl. The derived key
+//! is computed from a root key (VCEK or VMRK) mixed with configurable parameters
+//! such as VMPL, Guest Field Select bits, guest SVN, TCB version, and launch
+//! mitigation vector.
+//!
+//! ## `key`
+//!
+//! ```bash
+//! snpguest key $KEY_PATH $ROOT_KEY_SELECT [OPTIONS]
+//! ```
+//!
+//! ## Arguments and Options
+//!
+//! | :--      | :--        | :--    |
+//! | `$KEY_PATH` | The path to store the derived key. | *required* |
+//! | `$ROOT_KEY_SELECT` | The root key from which to derive the key (either `vcek` or `vmrk`). | *required* |
+//! | `-v, --vmpl` | The VMPL value to mix into the key (0-3). Must be greater than or equal to the current VMPL. | 1 |
+//! | `-g, --guest_field_select` | Guest Field Select bits to enable as a 64-bit integer (decimal, `0x`-prefixed hex or `0b`-prefixed bin). | 0 |
+//! | `-s, --guest_svn` | Specifies the guest SVN to mix into the key (decimal, prefixed hex or prefixed bin). | 0 |
+//! | `-t, --tcb_version` | Specifies the TCB version to mix into the derived key (decimal, prefixed hex or prefixed bin). Must not exceed the commited TCB. | 0 |
+//! | `-l, --launch_mit_vector` | Specifies the launch mitigation vector value to mix into the derived key (decimal, prefixed hex or prefixed bin). Only available for `MSG_KEY_REQ` message version ≥ 2. | — |
+//!
+//! ## Structure of Guest Field Select
+//!
+//! | Bit      | Field             | Note |
+//! | :--      | :--               | :--  |
+//! | 63:7     | (Reserved)        | Currently unused. |
+//! | 6 (MSB)  | Launch MIT Vector | Set to 0 if not specified; supported for `MSG_KEY_REQ` message version ≥ 2. |
+//! | 5        | TCB Version       |      |
+//! | 4        | SVN               |      |
+//! | 3        | Measurement       |      |
+//! | 2        | Family ID         |      |
+//! | 1        | Image ID          |      |
+//! | 0 (LSB)  | Guest Policy      |      |
+//!
+//! For example, all of
+//!
+//! - `--guest_field_select 49`
+//! - `--guest_field_select 0x31`
+//! - `--guest_field_select 0b110001`
+//!
+//! denote the following selection:
+//!
+//! ```plaintext
+//! Guest Policy: On (1),
+//! Image ID: Off (0),
+//! Family ID: Off (0),
+//! Measurement: Off (0),
+//! SVN: On (1),
+//! TCB Version: On (1),
+//! Launch MIT Vector: Off or None (0).
+//! ```
+//!
+//! ## Example
+//!
+//! ```bash
+//! # Creating and storing a derived key
+//! snpguest key derived-key.bin vcek --guest_field_select 0b110001 --guest_svn 2 --tcb_version 1 --vmpl 3
+//! ```
 
 use super::*;
 use sev::firmware::guest::{DerivedKey, Firmware, GuestFieldSelect};
 use std::io::Read;
 use std::{fs, path::PathBuf};
 
+/// CLI arguments for the `key` subcommand.
+///
+/// Requests a derived key from the AMD-SP and stores it in a file.
+/// The key is derived from a root key (VCEK or VMRK) mixed with the
+/// specified parameters.
 #[derive(Parser)]
 pub struct KeyArgs {
-    /// This is the path where the derived key will be saved.
+    /// Path where the derived key will be stored.
     #[arg(value_name = "key-path", required = true)]
     pub key_path: PathBuf,
 
-    /// This is the root key from which to derive the key. Input either VCEK or VMRK.
+    /// Root key from which to derive the key (`vcek` or `vmrk`).
     #[arg(value_name = "root-key-select", required = true, ignore_case = true)]
     pub root_key_select: String,
 
-    /// Specify an integer VMPL level between 0 and 3 that the Guest is running on.
+    /// VMPL (Virtual Machine Privilege Level) to mix into the key (0-3).
+    /// Must be greater than or equal to the current VMPL. Default is 1.
     #[arg(short, long, value_name = "vmpl", default_value = "1")]
     pub vmpl: u32,
 
-    /// Specify which Guest Field Select bits to enable. It is 64-bit wide but only the least-significant 6 bits (Message Version 1) or 7 bits (Message Version 2) are currently defined; all higher bits must be zero. The bits (LSB->MSB) are: 0 = Guest Policy, 1 = Image ID, 2 = Family ID, 3 = Measurement, 4 = SVN, 5 = TCB Version, 6 = Launch Mitigation Vector (only available for Message Version 2). Accepts an integer in decimal (e.g. `63`), prefixed hex (e.g. `0x3f`) or prefixed bin (e.g. `0b111111`).
+    /// Guest Field Select bits to enable as a 64-bit integer. Only the
+    /// least-significant 6 bits (message version 1) or 7 bits (message
+    /// version 2) are defined; higher bits must be zero. Bits (LSB to MSB):
+    /// 0=Guest Policy, 1=Image ID, 2=Family ID, 3=Measurement, 4=SVN,
+    /// 5=TCB Version, 6=Launch Mitigation Vector (version 2 only).
+    /// Accepts decimal, `0x`-prefixed hex, or `0b`-prefixed binary.
     #[arg(short, long = "guest_field_select", value_name = "gfs", value_parser = clparser::parse_int_auto_radix::<u64>, default_value = "0")]
     pub gfs: u64,
 
-    /// Specify the guest SVN to mix into the key. Must not exceed the guest SVN provided at launch in the ID block. Accepts an integer in decimal, prefixed hex or prefixed bin.
+    /// Guest SVN to mix into the key. Must not exceed the guest SVN
+    /// provided at launch in the ID block. Accepts decimal, `0x`-prefixed
+    /// hex, or `0b`-prefixed binary.
     #[arg(short = 's', long = "guest_svn", value_name = "gsvn", value_parser = clparser::parse_int_auto_radix::<u32>, default_value = "0")]
     pub gsvn: u32,
 
-    /// Specify the TCB version to mix into the derived key. Must not exceed CommittedTcb. Accepts an integer in decimal, prefixed hex or prefixed bin.
+    /// TCB version to mix into the derived key. Must not exceed the
+    /// committed TCB. Accepts decimal, `0x`-prefixed hex, or `0b`-prefixed
+    /// binary.
     #[arg(short, long = "tcb_version", value_name = "tcbv", value_parser = clparser::parse_int_auto_radix::<u64>, default_value = "0")]
     pub tcbv: u64,
 
-    /// Specify the launch mitigation vector to mix into the derived key (only available for Message Version 2). Accepts an integer in decimal, hexadecimal or binary string.
+    /// Launch mitigation vector to mix into the derived key. Only available
+    /// for `MSG_KEY_REQ` message version 2. When provided, the message version
+    /// is automatically set to 2. Accepts decimal, `0x`-prefixed hex, or
+    /// `0b`-prefixed binary.
     #[arg(short, long = "launch_mit_vector", value_name = "lmv", value_parser = clparser::parse_int_auto_radix::<u64>)]
     pub lmv: Option<u64>,
 }
 
+/// Request a derived key from the AMD-SP and write it to a file.
+///
+/// Validates arguments, constructs a `DerivedKey` request, sends it to the
+/// firmware via `/dev/sev-guest`, and serializes the resulting 32-byte key
+/// to the specified path.
 pub fn get_derived_key(args: KeyArgs) -> Result<()> {
-    // Validate arguments
     let root_key_select = match args.root_key_select.as_str() {
         "vcek" => false,
         "vmrk" => true,
@@ -55,10 +139,9 @@ pub fn get_derived_key(args: KeyArgs) -> Result<()> {
         return Err(anyhow::anyhow!("Invalid Guest Field Select option."));
     }
 
-    // Switch message version of MSG_KEY_REQ
+    // Automatically set message version 2 when launch mitigation vector is provided
     let msg_ver = if args.lmv.is_some() { 2 } else { 1 };
 
-    // Request derived key
     let request = DerivedKey::new(
         root_key_select,
         GuestFieldSelect(args.gfs),
@@ -72,10 +155,8 @@ pub fn get_derived_key(args: KeyArgs) -> Result<()> {
         .get_derived_key(Some(msg_ver), request)
         .context("Failed to request derived key")?;
 
-    // Create derived key path
     let key_path: PathBuf = args.key_path;
 
-    // Write derived key into desired file
     let mut key_file = if key_path.exists() {
         std::fs::OpenOptions::new()
             .write(true)
@@ -92,10 +173,10 @@ pub fn get_derived_key(args: KeyArgs) -> Result<()> {
     Ok(())
 }
 
+/// Read a derived key file and return its contents as a byte vector.
 pub fn read_key(key_path: PathBuf) -> Result<Vec<u8>, anyhow::Error> {
     let mut key_file = fs::File::open(key_path)?;
     let mut key = Vec::new();
-    // read the whole file
     key_file.read_to_end(&mut key)?;
     Ok(key)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,252 @@
 // SPDX-License-Identifier: Apache-2.0
-// This is the main entry point of the snpguest utility. The CLI includes subcommands for requesting and managing certificates, displaying information, fetching derived keys, and verifying certificates and attestation reports.
+
+//! # snpguest
+//!
+//! `snpguest` is a Command Line Interface utility for managing an AMD SEV-SNP
+//! enabled guest. This tool allows users to interact with the AMD SEV-SNP guest
+//! firmware device (`/dev/sev-guest`) enabling various operations such as:
+//!
+//! - **Attestation**: Request attestation reports from the AMD Secure Processor.
+//! - **Certificate management**:Get cached certificates from the hypervisor,
+//!   or fetch certificates from the AMD Key Distribution Service (KDS).
+//! - **Verification**: Verify certificate chains and attestation report.
+//! - **Derived key generation**: Request derived keys from the AMD-SP.
+//! - **Pre-attestation**: Calculate expected/reference values of launch
+//!   measurements, OVMF hashes, ID blocks, and key digests for use in
+//!   confidential VM provisioning.
+//!
+//! ## Basic Usage
+//!
+//! ```sh
+//! snpguest [GLOBAL_OPTIONS] [COMMAND] [COMMAND_ARGS] [SUBCOMMAND] [SUBCOMMAND_ARGS]
+//! ```
+//!
+//! Every `snpguest` (sub)command comes with a `-h, --help` option for a
+//! description of its use.
+//!
+//! ## Subcommands
+//!
+//! | Command | Subcommand | Description |
+//! |---------|------------|-------------|
+//! | [`ok`] | — | Quick local check if SEV-SNP is enabled in the guest environment |
+//! | [`report`] | — | Requests an attestation report from AMD-SP (or vTPM) |
+//! | [`certificates`](certs) | — | Requests certificates from the hypervisor memory via AMD-SP |
+//! | [`fetch`] | `ca`, `vcek`, `crl` | Fetches certificates/CRLs from AMD KDS |
+//! | [`verify`] | `certs`, `attestation` | Verifies certificates / attestation report |
+//! | [`key`] | — | Requests the derived key from AMD-SP based on input parameters |
+//! | [`display`] | `report`, `key` | Displays files in human-readable form |
+//! | [`generate`](preattestation) | `measurement`, `ovmf-hash`, `id-block`, `key-digest` | Calculates reference values |
+//!
+//! ## [Extended Attestation Workflow](#extended-attestation-flowchart)
+//!
+//! ![Extended attestation diagram](https://github.com/virtee/snpguest/blob/main/docs/extended.PNG?raw=true)
+//!
+//! **Step 1.** Request the attestation report by providing the two mandatory
+//! parameters - `$ATT_REPORT_PATH` which is the path pointing to where the
+//! user wishes to store the attestation report and `$REQUEST_FILE` which is
+//! the path pointing to where the request file used to request the attestation
+//! report is stored. The optional parameter `-v, --vmpl` specifies the vmpl
+//! level for the attestation report and is set to 1 by default. The flag
+//! `-r, --random` generates random data to be used as request data for the
+//! attestation report. Lastly, the flag `-p, --platform` obtains both the
+//! attestation report and the request data from the platform (only available
+//! for a Microsoft Azure CVM where Hyper-V guest is enabled).
+//!
+//! ```bash
+//! snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random] [-p, --platform]
+//! ```
+//!
+//! **Step 2.** Request certificates from the extended memory by providing the
+//! two mandatory parameters - `$ENCODING` which specifies whether to use PEM
+//! or DER encoding to store the certificates and $CERTS_DIR which specifies
+//! the path in the user's directory where the certificates will be saved.
+//!
+//! ```bash
+//! snpguest certificates $ENCODING $CERTS_DIR
+//! ```
+//!
+//! In some environments, only the VCEK/VLEK certificate can be obtained. In
+//! this case, you must follow the procedure described in
+//! [Regular Attestation Workflow](#regular-attestation-workflow) to obtain an
+//! AMD CA certificates.
+//!
+//! **Step 3.** Verify the certificates obtained from the extended memory by
+//! providing `$CERTS_DIR` which specifies the path in the user's directory
+//! where the certificates were saved from Step 2.
+//!
+//! ```bash
+//! snpguest verify certs $CERTS_DIR
+//! ```
+//!
+//! **Step 4.** Verify the attestation by providing the two mandatory
+//! parameters - `$CERTS_DIR` which specifies the path in the user's directory
+//! where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which
+//! is the path pointing to the stored attestation report which the user
+//! wishes to verify. The optional parameters `-t, --tcb` is used to verify
+//! just the Reported TCB contents of the attestaion report and
+//! `-s, --signature` is used to verify just the signature of the attestaion
+//! report.
+//!
+//! ```bash
+//! snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [-t, --tcb] [-s, --signature]
+//! ```
+//!
+//! ## [Regular Attestation Workflow](#regular-attestation-flowchart)
+//!
+//! ![Regular attestation diagram](https://github.com/virtee/snpguest/blob/main/docs/regular.PNG?raw=true)
+//!
+//! **Step 1.** Request the attestation report by providing the two mandatory
+//! parameters - `$ATT_REPORT_PATH` which is the path pointing to where the
+//! user wishes to store the attestation report and `$REQUEST_FILE` which is
+//! the path pointing to where the request file used to request the attestation
+//! report is stored. The optional parameter `-v, --vmpl` specifies the vmpl
+//! level for the attestation report and is set to 1 by default. The flag
+//! `-r, --random` generates random data to be used as request data for the
+//! attestation report. Lastly, the flag `-p, --platform` obtains both the
+//! attestation report and the request data from the platform (only available
+//! for a Microsoft Azure CVM where Hyper-V guest is enabled).
+//!
+//! ```bash
+//! snpguest report $ATT_REPORT_PATH $REQUEST_FILE [-v, --vmpl] $VMPL [-r, --random] [-p, --platform]
+//! ```
+//!
+//! **Step 2.** Request AMD Root Key (ARK) and AMD SEV Key (ASK) (or AMD
+//! SEV-VLEK Key (ASVK) for VLEK) from the AMD Key Distribution Service (KDS)
+//! by providing the three mandatory parameters - `$ENCODING` which specifies
+//! whether to use PEM or DER encoding to store the certificates, `$CERTS_DIR`
+//! which specifies the path in the user's directory where the certificates
+//! will be saved, and `$PROCESSOR_MODEL` - which specifies the AMD Processor
+//! model for which the certificates are to be fetched. The optional
+//! `-e, --endorser` argument specifies the type of attestation signing key
+//! (defaults to VCEK).
+//!
+//! ```bash
+//! snpguest fetch ca $ENCODING $CERTS_DIR $PROCESSOR_MODEL [-e, --endorser] $ENDORSER
+//! ```
+//!
+//! **Step 3.** Request the Versioned Chip Endorsement Key (VCEK) from the AMD
+//! Key Distribution Service (KDS) by providing the three mandatory
+//! parameters - `$ENCODING` which specifies whether to use PEM or DER
+//! encoding to store the certificates, `$CERTS_DIR` which specifies the path
+//! in the user's directory where the certificates will be saved, and
+//! `$ATT_REPORT_PATH` which is the path pointing to the stored attestation
+//! report for detecting Chip ID and Reported TCB Version. The optional
+//! `-p, --processor-model` argument specifies the AMD Processor model for
+//! which the certificates are to be fetched.
+//!
+//! ```bash
+//! snpguest fetch vcek $ENCODING $CERTS_DIR $ATT_REPORT_PATH [-p, --processor-model] $PROCESSOR_MODEL
+//! ```
+//!
+//! **Step 4.** Verify the certificates obtained by providing `$CERTS_DIR`
+//! which specifies the path in the user's directory where the certificates
+//! were saved from Step 2.
+//!
+//! ```bash
+//! snpguest verify certs $CERTS_DIR
+//! ```
+//!
+//! **Step 5.** Verify the attestation by providing the two mandatory
+//! parameters - `$CERTS_DIR` which specifies the path in the user's directory
+//! where the certificates were saved from Step 2 and `$ATT_REPORT_PATH` which
+//! is the path pointing to the stored attestation report which the user
+//! wishes to verify. The optional parameters `-t, --tcb` is used to verify
+//! just the Reported TCB contents of the attestaion report and
+//! `-s, --signature` is used to verify just the signature of the attestaion
+//! report.
+//!
+//! ```bash
+//! snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [-t, --tcb] [-s, --signature]
+//! ```
+//!
+//! ## Build
+//!
+//! ### For Standard CVMs
+//!
+//! ```bash
+//! # Build
+//! git clone https://github.com/virtee/snpguest
+//! cd snpguest
+//! cargo build -r
+//!
+//! # Install from the repository
+//! cargo install --git https://github.com/virtee/snpguest
+//!
+//! # Install from crate.io
+//! cargo install snpguest
+//! ```
+//!
+//! ### For Azure CVMs
+//!
+//! On Azure CVMs, all communication between the guest OS and AMD-SP is proxied
+//! by the OpenHCL paravisor. The native `/dev/sev-guest` interface is hidden
+//! from the guest OS. The user must specify the `--platform` flag to get an
+//! attestation report; this flag is available only in builds compiled with the
+//! `hyperv` feature.
+//!
+//! ```bash
+//! # Install additional dependencies
+//! sudo apt update
+//! sudo apt install -y pkg-config libtss2-dev
+//!
+//! # Build
+//! git clone https://github.com/virtee/snpguest
+//! cd snpguest
+//! cargo build -r --features hyperv
+//!
+//! # Install from the repository
+//! cargo install --git https://github.com/virtee/snpguest --features hyperv
+//!
+//! # Install from crate.io
+//! cargo install snpguest --features hyperv
+//! ```
+//!
+//! ### Build Dependencies
+//!
+//! Some packages may need to be installed on the guest system in order to
+//! build `snpguest`.
+//!
+//! #### Rust
+//!
+//! ```bash
+//! curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+//! source "$HOME/.cargo/env"
+//! ```
+//!
+//! #### Ubuntu Dependencies
+//!
+//! ```bash
+//! sudo apt install build-essential
+//! ```
+//!
+//! #### RHEL and its compatible distributions Dependencies
+//!
+//! ```bash
+//! sudo dnf groupinstall "Development Tools" "Development Libraries"
+//! ```
+//!
+//! #### openSUSE and its compatible distributions Dependencies
+//!
+//! ```bash
+//! sudo zypper in -t pattern "devel_basis"
+//! ```
+//!
+//! ### Load sev-guest module
+//!
+//! In some guest environments, the device `/dev/sev-guest` does not created
+//! by default. In such cases, make sure that the kernel supports SEV-SNP,
+//! then load the sev-guest module.
+//!
+//! ```bash
+//! modprobe sev-guest
+//! ls -l /dev/sev-guest
+//! ```
+//!
+//! ## Reporting Bugs
+//!
+//! Please report all bugs to the [Github snpguest](https://github.com/virtee/snpguest/issues) repository.
+
+#![deny(missing_docs)]
 
 mod certs;
 mod display;
@@ -26,50 +273,52 @@ use verify::VerifyCmd;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
+/// Top-level CLI structure for `snpguest`.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct SnpGuest {
     #[command(subcommand)]
     pub cmd: SnpGuestCmd,
 
-    /// Don't print anything to the console
+    /// Suppress console output.
     #[arg(short, long, default_value_t = false)]
     pub quiet: bool,
 }
 
+/// Available subcommands for managing the SEV-SNP guest environment.
 #[allow(clippy::large_enum_variant)]
-/// Utilities for managing the SNP Guest environment
 #[derive(Subcommand)]
 enum SnpGuestCmd {
-    /// Report command to request an attestation report.
+    /// Request an attestation report from the AMD Secure Processor (or vTPM).
     Report(ReportArgs),
 
-    /// Certificates command to request cached certificates from the AMD PSP.
+    /// Request cached certificates from the hypervisor memory via the AMD Secure Processor.
     Certificates(CertificatesArgs),
 
-    /// Fetch command to request certificates.
+    /// Fetch certificates or CRLs from the AMD Key Distribution Service (KDS).
     #[command(subcommand)]
     Fetch(FetchCmd),
 
-    /// Verify command to verify certificates and attestation report.
+    /// Verify certificate chains or attestation reports.
     #[command(subcommand)]
     Verify(VerifyCmd),
 
-    /// Display command to display files in human readable form.
+    /// Display attestation reports or derived keys in human-readable form.
     #[command(subcommand)]
     Display(DisplayCmd),
 
-    /// Key command to generate derived key.
+    /// Request a derived key from the AMD Secure Processor.
     Key(KeyArgs),
 
-    /// Probe system for SEV-SNP support.
+    /// Quick local check if SEV-SNP is enabled in the guest environment.
     Ok,
 
-    /// Generate Pre-Attestation components
+    /// Calculate pre-attestation reference values (measurements, OVMF hashes, ID blocks, key digests).
     #[command(subcommand)]
     Generate(PreAttestationCmd),
 }
 
+/// Entry point: parses CLI arguments and dispatches to the appropriate subcommand handler.
 fn main() -> Result<()> {
     env_logger::init();
 

--- a/src/ok.rs
+++ b/src/ok.rs
@@ -1,5 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file contains code for checking if the SEV-SNP feature appears enabled in the guest environment.
+
+//! Quick check if the SEV-SNP is enabled.
+//!
+//! This module provides the `ok` subcommand which performs a quick local check
+//! of the guest using features such as CPUID and MSRs (Model-Specific Registers)
+//! to determine whether SEV-SNP appears to be enabled in the guest environment.
+//!
+//! ## `ok`
+//!
+//! ```bash
+//! snpguest ok
+//! ```
+//!
+//! Note that this command is only a sanity check and does not provide a cryptographic
+//! guarantee that the SEV-SNP is definitely valid. To obtain strict cryptographic
+//! assurance for the SEV-SNP, the user must perform remote attestation.
+//!
+//! This command requires the `msr` module.
 
 use super::*;
 
@@ -13,8 +30,11 @@ use serde::{Deserialize, Serialize};
 const SEV_MASK: usize = 1;
 const ES_MASK: usize = 1 << 1;
 const SNP_MASK: usize = 1 << 2;
+
+/// Type alias for test functions that return a [`TestResult`].
 type TestFn = dyn Fn() -> TestResult;
 
+/// A single capability test with optional sub-tests.
 struct Test {
     name: &'static str,
     gen_mask: usize,
@@ -22,12 +42,14 @@ struct Test {
     sub: Vec<Test>,
 }
 
+/// Result of a single capability test.
 struct TestResult {
     name: String,
     stat: TestState,
     mesg: Option<String>,
 }
 
+/// Possible outcomes of a capability test.
 #[derive(PartialEq, Eq)]
 enum TestState {
     Pass,
@@ -36,6 +58,10 @@ enum TestState {
 }
 
 bitfield! {
+    /// Bitfield representing the SEV status MSR (`0xC0010131`).
+    ///
+    /// Each bit indicates whether a specific SEV/SEV-ES/SNP feature
+    /// is enabled in the guest environment.
     #[repr(C)]
     #[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct SevStatus(u64);
@@ -249,6 +275,10 @@ fn collect_tests() -> Vec<Test> {
 
 const INDENT: usize = 2;
 
+/// Run all SEV-SNP capability tests and report results.
+///
+/// Returns `Ok(())` if all required tests pass, or an error if any fail.
+/// Optional features are reported but do not cause failure.
 pub fn cmd(quiet: bool) -> Result<()> {
     let tests = collect_tests();
 

--- a/src/preattestation.rs
+++ b/src/preattestation.rs
@@ -1,5 +1,202 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file defines the CLI for pre-attestation related processes, such as calculating the measurement or generating an ID-BLOCK
+
+//! Pregenerates reference values.
+//!
+//! This module provides the following subcommands, which calculate pre-attestation
+//! reference value.
+//!
+//! - `generate measurement` — Calculate the expected launch measurement digest.
+//! - `generate ovmf-hash` — Calculate the hash of an OVMF binary.
+//! - `generate id-block` — Generate an ID block and auth block for guest launch.
+//! - `generate key-digest` — Generate an SEV key digest for an EC P-384 key.
+//!
+//! ## `generate measurement`
+//!
+//! ```bash
+//! snpguest generate measurement [OPTIONS]
+//! ```
+//!
+//! Calculates an expected launch digest measurement of secure guest, and prints
+//! it into the terminal or stores it into the specified path.
+//!
+//! ### Options
+//!
+//! | Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `-v, --vcpus` | Number of guest vCPUs. | 1 |
+//! | `--vcpu-type` | Type of guest vCPU. Either this parameter, `--vcpu-sig`, or the triplet (`--vcpu-family`, `--vcpu-model`, `--vcpu-stepping`) must be specified. (Conflicts with the other `--vcpu-*` parameters) | *required* |
+//! | `--vcpu-sig` | Guest vCPU signature value. (Conflicts with the other `--vcpu-*` options) | - |
+//! | `--vcpu-family`, `--vcpu-model`, `--vcpu-stepping` | Guest vCPU family, model, and stepping. When specifying the vCPU type using these options, all three options must be specified. (Conflicts with `--vcpu-type` and `--vcpu-sig`) | - |
+//! | `--vmm-type` | Guest VMM type (QEMU, EC2, KRUN). | - |
+//! | `-o, --ovmf` | OVMF file path to calculate measurement from. Either this option or `--ovmf-hash` must be specified. (Conflicts with `--ovmf-hash`) | *required* |
+//! | `-k, --kernel` | Kernel file path to calculate measurement from. | - |
+//! | `-i, --initrd` | Initrd file path to calculate measurement from. (Requires `--kernel`) | - |
+//! | `-a, --append` | Kernel command line to calculate measurement from. (Requires `--kernel`) | - |
+//! | `-g, --guest-features` | Decimal or prefixed-hex representation of the guest kernel features expected to be included. | `0x1` |
+//! | `--ovmf-hash` | Precalculated hash of the OVMF binary. (Conflicts with `--ovmf`) | - |
+//! | `-f, --output-format` | Output format (`base64` or `hex`). | `hex` |
+//! | `-m, --measurement-file` | Optional file path where measurement value can be stored in. | stdout |
+//!
+//! Every parameter passed in is used to calculate this measurement, but the user
+//! does not need to provide every parameter.
+//!
+//! The only mandatory parameters are the `-o, --ovmf` parameter which is a path
+//! to the ovmf file used to launch the secure guest, and provide the guest vCPU
+//! type.
+//!
+//! There are 3 ways to provide the vCPU type, and the 3 of them are mutually
+//! exclusive (will get an error if the user tries to use more than one method):
+//!
+//! - `--vcpu-type` A string with the vcpu-type used to launch the secure guest
+//! - `--vcpu-sig` The signature of the vcpu-type used to launch the secure guest
+//! - `--vcpu-family, --vcpu-model, --vcpu-stepping` The family, model and
+//!   stepping of the vcpu used to launch the secure guest. Family, model and
+//!   stepping have to be used together, if they are not all provided together
+//!   an error will be raised.
+//!
+//! If the user specifies the `-k, --kernel` parameter to calculate measurements,
+//! they can also specify `-i, --initrd` and `-a, --append`. These parameters
+//! are unnecessary if the kernel file already contains initrd and append.
+//!
+//! There were kernel features added that affect the result of the measurement
+//! if those are enabled. With the `-g, --guest-features` parameter the user can
+//! provide which of this features are enabled in their kernel.
+//!
+//! The `-g, --guest-features` can be a hex or decimal number that cover the
+//! features enabled. For information on the guest-features bitfield checkout
+//! [virtee/sev/src/measurement/vmsa.rs](https://github.com/virtee/sev/blob/main/src/measurement/vmsa.rs).
+//!
+//! A user can use a pre-calculated ovmf-hash using `--ovmf-hash`, but the ovmf
+//! file still has to be provided.
+//!
+//! The calculated measurement will be printed in the console. If the user
+//! wishes to store the measurement value they can provide a file path with
+//! `-m, --measurement-file` and the measurement will get written there.
+//!
+//! If the global `-q, --quiet` flag is used, nothing will be printed out.
+//!
+//! ### List of vCPU types
+//!
+//! Currently the following vCPU types are available. The vCPU signature value
+//! can be calculated from the cprresponding vCPU (family, model, stepping).
+//! For details, see [AMD's CPUID Specification](https://www.amd.com/content/dam/amd/en/documents/archived-tech-docs/design-guides/25481.pdf).
+//!
+//! | vcpu_type | vcpu_family | vcpu_model | vcpu_stepping |
+//! | :-- | :-- | :-- | :-- |
+//! | `epyc` | 23 | 1 | 2 |
+//! | `epyc-v1` | | | |
+//! | `epyc-v2` | | | |
+//! | `epyc-ibpb` | | | |
+//! | `epyc-v3` | | | |
+//! | `epyc-v4` | | | |
+//! | `epyc-rome` | 23 | 49 | 0 |
+//! | `epyc-rome-v1` | | | |
+//! | `epyc-rome-v2` | | | |
+//! | `epyc-rome-v3` | | | |
+//! | `epyc-milan` | 25 | 1 | 1 |
+//! | `epyc-milan-v1` | | | |
+//! | `epyc-milan-v2` | | | |
+//! | `epyc-genoa` | 25 | 17 | 0 |
+//! | `epyc-genoa-v1` | | | |
+//!
+//! ## `generate ovmf-hash`
+//!
+//! ```bash
+//! snpguest generate ovmf-hash [OPTIONS]
+//! ```
+//!
+//! Calculates the hash of an ovmf file.
+//!
+//! ### Options
+//!
+//! | Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `-o, --ovmf` | Path to OVMF file to calculate hash from | *required* |
+//! | `-f, --output-format` | Output format (`hex` or `base64`) | `hex` |
+//! | `--hash-file` | Optional file where hash value can be stored in | stdout |
+//!
+//! The user must specify the OVMF file using the `-o, --ovmf` option.
+//!
+//! The user can specify the output format using the `-f, --output-format`
+//! option: "hex" or "base64" (default: "hex").
+//!
+//! The hash will be printed in the console, if the user wishes to store the
+//! hash value they can provide a file path with `--hash-file` and the hash
+//! will get written there.
+//!
+//! If the global `-q, --quiet` flag is used, nothing will be printed out.
+//!
+//! ## `generate id-block`
+//!
+//! ```bash
+//! snpguest generate id-block $ID_BLOCK_KEY $AUTH_KEY $LAUNCH_DIGEST [OPTIONS]
+//! ```
+//!
+//! Calculates an id-block and auth-block for a secure guest.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ID_BLOCK_KEY` | Path to the Id-Block key | *required* |
+//! | `$AUTH_KEY` | Path to the Auth-Block key | *required* |
+//! | `$LAUNCH_DIGEST` | Guest launch measurement in either Base64 encoding or hex (if hex prefix with 0x) | *required* |
+//! | `-f, --family-id` | Family ID of the guest provided by the guest owner (16 bytes) | 0s |
+//! | `-m, --image-id` | Image ID of the guest provided by the guest owner (16 bytes) | 0s |
+//! | `-v, --version` | Id-Block version. Currently only version 1 is available | 1 |
+//! | `-s, --svn` | SVN of the guest | 0 |
+//! | `-p, --policy` | Launch policy of the guest. Can provide in decimal or hex format. | 0x30000 |
+//! | `-i, --id-file` | Optional file where the Id-Block value can be stored in | stdout |
+//! | `-a, --auth-info-file` | Optional file where the Auth-Block value can be stored in | stdout |
+//!
+//! The user needs to provide a path to two different EC P-384 keys
+//! `$ID_BLOCK_KEY` and `$AUTH_KEY` in PEM or DER format. One will be for the
+//! id-block the other for the auth-block.
+//!
+//! The user also needs to provide the launch digest `$LAUNCH_DIGEST` (in either
+//! hex or base64 format) of the secure guest. The user can generate the launch
+//! digest using the `generate measurement` command.
+//!
+//! The user can provide optional id's for further verification using the
+//! `-f, --family-id` and `-m, image-id` paramerters. Each parameter is 16 raw
+//! bytes (default: 0s).
+//!
+//! The user can provide the security version number of the guest using
+//! `-s, --svn` (default: 0).
+//!
+//! The user can specify the launch policy of the guest using the `-p, --policy`
+//! parameter. The policy can be provided in either hex or decimal format. It
+//! will default to 0x30000. For more information on the guest-policy, see
+//! [SEV-SNP Firmware ABI Specification](https://www.amd.com/content/dam/amd/en/documents/developer/56860.pdf).
+//!
+//! The blocks will be printed in the console, if the user wishes to store the
+//! blocks values they can provide a file path with `-i, --id-file` for the
+//! id-block and `-a, --auth-file` for the auth-block.
+//!
+//! If the global `-q, --quiet` flag is used, nothing will be printed out.
+//!
+//! ## `generate key-digest`
+//!
+//! ```bash
+//! snpguest generate key-digest $KEY_PATH [-d, --key-digest-file]
+//! ```
+//!
+//! Generates an SEV key digest for a provided EC P-384 key.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$KEY_PATH` | Path to key to generate hash for | *required* |
+//! | `-d, --key-digest-file` | File to store the key digest in | stdout |
+//!
+//! User needs to provide a path to the key `$KEY_PATH`. The key has to be an
+//! EC P-384 key in either PEM or DER format.
+//!
+//! The digest will be printed in the console. If the user wishes to store the
+//! digest value they can provide a file path with `-d, --key-digest-file`.
+//!
+//! If the global `-q, --quiet` flag is used, nothing will be printed out.
 
 use super::*;
 use base64::{engine::general_purpose, Engine as _};
@@ -17,21 +214,23 @@ use sev::{
 };
 use std::{fs::OpenOptions, io::Write, path::PathBuf};
 
+/// Subcommands for generating pre-attestation reference values.
 #[derive(Subcommand)]
 pub enum PreAttestationCmd {
-    /// Calculate the Measurement of a confidential VM with the supplied parameters
+    /// Calculate the expected launch measurement digest of a confidential VM.
     Measurement(measurement::Args),
 
-    /// Calculated the hash of an OVMF file
+    /// Calculate the hash of an OVMF binary.
     OvmfHash(ovmf_hash::Args),
 
-    /// Generate an ID-Block and Auth-Block for a confidential VM with the supplied parameters
+    /// Generate an ID block and auth block for a confidential VM.
     IdBlock(idblock::Args),
 
-    /// Generate a SEV key digest for the provided openssl key.
+    /// Generate an SEV key digest for an EC P-384 key.
     KeyDigest(keydigest::Args),
 }
 
+/// Dispatch to the appropriate generate subcommand handler.
 pub fn cmd(cmd: PreAttestationCmd, quiet: bool) -> Result<()> {
     match cmd {
         PreAttestationCmd::Measurement(args) => measurement::generate_measurement(args, quiet),
@@ -47,62 +246,70 @@ mod measurement {
 
     use super::*;
 
+    /// CLI arguments for `generate measurement`.
+    ///
+    /// Calculates the expected launch measurement digest of a confidential VM.
+    /// The vCPU type must be specified using one of three mutually exclusive
+    /// methods: `--vcpu-type`, `--vcpu-sig`, or the triplet
+    /// (`--vcpu-family`, `--vcpu-model`, `--vcpu-stepping`).
     #[derive(Parser, Debug)]
     pub struct Args {
-        /// Number of guest vcpus
+        /// Number of guest vCPUs.
         #[arg(short, long, default_value = "1")]
         pub vcpus: u32,
 
-        /// Type of guest vcpu (EPYC, EPYC-v1, EPYC-v2, EPYC-IBPB, EPYC-v3, EPYC-v4,
-        /// EPYC-Rome, EPYC-Rome-v1, EPYC-Rome-v2, EPYC-Rome-v3, EPYC-Milan, EPYC-
-        /// Milan-v1, EPYC-Milan-v2, EPYC-Genoa, EPYC-Genoa-v1)
-        #[arg(long, value_name = "vcpu-type", 
-            conflicts_with_all = ["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"], 
+        /// Type of guest vCPU (e.g., EPYC, EPYC-v1, EPYC-Rome, EPYC-Milan, EPYC-Genoa).
+        /// Conflicts with `--vcpu-sig` and the family/model/stepping triplet.
+        #[arg(long, value_name = "vcpu-type",
+            conflicts_with_all = ["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"],
             required_unless_present_any(["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"],
         ), ignore_case = true)]
         pub vcpu_type: Option<String>,
 
-        /// Guest vcpu signature value
+        /// Guest vCPU signature value. Conflicts with `--vcpu-type` and the
+        /// family/model/stepping triplet.
         #[arg(long, value_name = "vcpu-sig", conflicts_with_all = ["vcpu_type", "vcpu_family", "vcpu_model", "vcpu_stepping"])]
         pub vcpu_sig: Option<i32>,
 
-        /// Guest vcpu family
+        /// Guest vCPU family. Must be used together with `--vcpu-model` and `--vcpu-stepping`.
         #[arg(long, value_name = "vcpu-family", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_model", "vcpu_stepping"])]
         pub vcpu_family: Option<i32>,
 
-        /// Guest vcpu model
+        /// Guest vCPU model. Must be used together with `--vcpu-family` and `--vcpu-stepping`.
         #[arg(long, value_name = "vcpu-model", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_family", "vcpu_stepping"])]
         pub vcpu_model: Option<i32>,
 
-        /// Guest vcpu stepping.
+        /// Guest vCPU stepping. Must be used together with `--vcpu-family` and `--vcpu-model`.
         #[arg(long, value_name = "vcpu-stepping", conflicts_with_all = ["vcpu_type", "vcpu_sig"], requires_all = ["vcpu_family", "vcpu_model"])]
         pub vcpu_stepping: Option<i32>,
 
-        /// Type of guest vmm (QEMU, ec2, KRUN)
+        /// Guest VMM type (QEMU, ec2, KRUN).
         #[arg(long, short = 't', value_name = "vmm-type", ignore_case = true)]
         pub vmm_type: Option<String>,
 
-        /// OVMF file to calculate measurement from
+        /// Path to the OVMF file to calculate measurement from.
         #[arg(short, long, value_name = "ovmf", required = true)]
         pub ovmf: PathBuf,
 
-        /// Kernel file to calculate measurement from
+        /// Path to the kernel file to include in measurement calculation.
         #[arg(short, long, value_name = "kernel")]
         pub kernel: Option<PathBuf>,
 
-        /// Initrd file to calculate measurement from
+        /// Path to the initrd file to include in measurement calculation.
+        /// Requires `--kernel`.
         #[arg(short, long, value_name = "initrd", requires = "kernel")]
         pub initrd: Option<PathBuf>,
 
-        /// Kernel command line to calculate measurement from
+        /// Kernel command line to include in measurement calculation.
+        /// Requires `--kernel`.
         #[arg(short, long, value_name = "append", requires = "kernel")]
         pub append: Option<String>,
 
-        /// Hex representation of the guest kernel features expected to be included, defaults to 0x1
+        /// Guest kernel features value (decimal or `0x`-prefixed hex). Defaults to 0x1.
         #[arg(short, long, value_name = "guest-features", value_parser=maybe_hex::<u64>)]
         pub guest_features: Option<u64>,
 
-        /// Precalculated hash of the OVMF binary
+        /// Precalculated hash of the OVMF binary. Conflicts with `--ovmf`.
         #[arg(
             long,
             value_name = "ovmf-hash",
@@ -111,7 +318,7 @@ mod measurement {
         )]
         pub ovmf_hash: Option<String>,
 
-        ///Choose output format (base64, hex).
+        /// Output format (`base64` or `hex`).
         #[arg(
             long,
             short = 'f',
@@ -121,11 +328,12 @@ mod measurement {
         )]
         pub output_format: String,
 
-        /// Optional file path where measurement value can be stored in
+        /// Optional file path to store the measurement value.
         #[arg(short = 'm', long, value_name = "measurement-file")]
         pub measurement_file: Option<PathBuf>,
     }
 
+    /// Calculate and output the expected launch measurement digest.
     pub fn generate_measurement(args: Args, quiet: bool) -> Result<()> {
         // Get VCPU type from either string, signature or family, model and step.
         let vcpu_type = if let Some(v_type) = args.vcpu_type {
@@ -204,13 +412,14 @@ mod measurement {
 mod ovmf_hash {
     use super::*;
 
+    /// CLI arguments for `generate ovmf-hash`.
     #[derive(Parser)]
     pub struct Args {
-        /// Path to OVMF file to calculate hash from
+        /// Path to the OVMF file to calculate the hash from.
         #[arg(short, long, value_name = "ovmf", required = true)]
         pub ovmf: PathBuf,
 
-        /// Choose output format (base64, hex). Defaults to hex
+        /// Output format (`hex` or `base64`).
         #[arg(
             short = 'f',
             long,
@@ -220,10 +429,12 @@ mod ovmf_hash {
         )]
         pub output_format: String,
 
-        /// Optional file where hash value can be stored in
+        /// Optional file path to store the hash value.
         #[arg(long, value_name = "hash-file")]
         pub hash_file: Option<PathBuf>,
     }
+
+    /// Calculate and output the OVMF hash.
     pub fn generate_ovmf_hash(args: Args, quiet: bool) -> Result<()> {
         let ovmf_hash = match calc_snp_ovmf_hash(args.ovmf) {
             Ok(ld) => {
@@ -260,49 +471,55 @@ mod idblock {
 
     use super::*;
 
+    /// CLI arguments for `generate id-block`.
+    ///
+    /// Generates an ID block and auth block for a confidential VM using
+    /// two EC P-384 keys (one for the ID block, one for the auth block)
+    /// and a launch digest. Output is in Base64 (the format QEMU accepts).
     #[derive(Parser)]
     pub struct Args {
-        /// Path to the Id-Block key
+        /// Path to the ID block signing key (EC P-384, PEM or DER).
         #[arg(value_name = "id-block-key", required = true)]
         pub id_block_key: PathBuf,
 
-        /// Path to the Auth-Block key
+        /// Path to the auth block signing key (EC P-384, PEM or DER).
         #[arg(value_name = "auth-key", required = true)]
         pub auth_key: PathBuf,
 
-        /// Guest launch measurement in either Base64 encoding or hex (if hex prefix with 0x)
+        /// Guest launch measurement in Base64 or `0x`-prefixed hex.
         #[arg(value_name = "launch-digest", required = true)]
         pub launch_digest: String,
 
-        /// Family ID of the guest provided by the guest owner in hex. Has to be 32 characters (16 bytes).
+        /// Family ID of the guest (32 hex characters = 16 bytes).
         #[arg(short, long, value_name = "family-id")]
         pub family_id: Option<String>,
 
-        /// Image ID of the guest provided by the guest owner in hex. Has to be 32 characters (16 bytes).
+        /// Image ID of the guest (32 hex characters = 16 bytes).
         #[arg(short = 'm', long, value_name = "image-id")]
         pub image_id: Option<String>,
 
-        /// Id-Block version. Currently only version 1 is available
+        /// ID block version (currently only version 1).
         #[arg(short, long, value_name = "version")]
         pub version: Option<u32>,
 
-        /// SVN of the guest
+        /// Security Version Number (SVN) of the guest.
         #[arg(short, long, value_name = "svn")]
         pub svn: Option<u32>,
 
-        /// Launch policy of the guest. Can provide in decimal or hex format.
+        /// Launch policy of the guest (decimal or `0x`-prefixed hex).
         #[arg(short, long, value_name = "policy", value_parser=maybe_hex::<u64>)]
         pub policy: Option<u64>,
 
-        /// Optional file where the Id-Block value can be stored in
+        /// Optional file path to store the ID block value (Base64).
         #[arg(short, long, value_name = "id-block-file")]
         pub id_file: Option<PathBuf>,
 
-        /// Optional file where the Auth-Block value can be stored in
+        /// Optional file path to store the auth block value (Base64).
         #[arg(short, long, value_name = "auth-info-file")]
         pub auth_file: Option<PathBuf>,
     }
 
+    /// Generate ID block and auth block, outputting as Base64.
     pub fn generate_id_block(args: Args, quiet: bool) -> Result<()> {
         let ld =
             if &args.launch_digest[..args.launch_digest.char_indices().nth(2).unwrap().0] == "0x" {
@@ -392,17 +609,19 @@ mod idblock {
 mod keydigest {
     use super::*;
 
+    /// CLI arguments for `generate key-digest`.
     #[derive(Parser)]
     pub struct Args {
-        /// Path to key to generate hash for
+        /// Path to the EC P-384 key (PEM or DER) to generate the digest for.
         #[arg(value_name = "key", required = true)]
         pub key: PathBuf,
 
-        /// File to store the key digest in
+        /// Optional file path to store the key digest (hex encoded).
         #[arg(short = 'd', long, value_name = "key-digest-file")]
         pub key_digest_file: Option<PathBuf>,
     }
 
+    /// Calculate and output the SEV key digest for the given key.
     pub fn calculate_key_digest(args: Args, quiet: bool) -> Result<()> {
         let kd = generate_key_digest(args.key)?;
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file defines the CLI for requesting attestation reports. It contains functions for requesting attestation reports and saving them to files. Additionally, it includes code for reading and parsing attestation reports.
+
+//! Requests attestation reports from AMD-SP or vTPM.
+//!
+//! This module provides the `report` subcommand which requests attestation
+//! reports from the AMD Secure Processor (via `/dev/sev-guest`) or from the
+//! vTPM (on Azure CVMs with the `hyperv` feature).
+//!
+//! The report request can include:
+//!
+//! - User-provided 64-byte request data read from a file
+//! - Randomly generated 64-byte request data (`--random`)
+//! - Platform-provided request data from the vTPM (`--platform`, Azure CVMs only)
+//!
+//! ## `report`
+//!
+//! ```sh
+//! snpguest report $ATT_REPORT_PATH $REQUEST_FILE [OPTIONS]
+//! ```
+//!
+//! Requests an attestation report from the AMD Secure Processor (ASP), and writes
+//! it as raw binary.
+//! This command is a wrapper of the `SNP_GUEST_REQUEST(MSG_REPORT_REQ)` ioctl.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$ATT_REPORT_PATH` | The path where the attestation report would be stored. | *required* |
+//! | `$REQUEST_FILE` | The path to the 64-byte request file. | *required* |
+//! | `-v, --vmpl $VMPL` | The VMPL value to put in the attestation report (0-3). Must be greater than or equal to the current VMPL. | 1 |
+//! | `-r, --random` | Generate 64 random bytes of data for the report request. | - |
+//! | `-p, --platform` | Get an attestation report from the vTPM NV index (Only available for Azure CVMs). | - |
+//!
+//! Without `-p, --platform` or `-r, --random`, the user can pass 64 bytes of
+//! data in any file format into `$REQUEST_FILE` to request an attestation report.
+//! The request file is interpreted as raw binary, and the first 64 bytes of the
+//! binary are sent to the AMD-SP as the request data. The request data will be
+//! bound to the REPORT_DATA field in the attestation report.
+//!
+//! With the `-r, --random` flag, this command generates a random data for the
+//! request, which will be written into `$REQUEST_FILE`.
+//!
+//! The `-v, --vmpl` option specifies the Virtual Machine Privilege Level (VMPL)
+//! to request an attestation report (0 to 3). The default value is 1. This
+//! value must be greater than or equal to the current VMPL. Specifying a
+//! privilege level higher than the actual level (smaller VMPL value) will result
+//! in a firmware error.
+//!
+//! With the `-p, --platform` flag, this command retrieves an attestation report
+//! from vTPM NV index `0x01400001` instead of the ASP, and writes the Report
+//! Data field in the retrieved report into `$REQUEST_FILE`. This attestation
+//! route is available (and mandatory) on Microsoft Azure Confidential VMs with
+//! SEV-SNP isolation. This flag requires the `hyperv` feature. Currently, only
+//! the pre-generated attestation report can be retrieved. To request a (fresh)
+//! report with the user-provided request data, use any TPM2 tool to write the
+//! request data to vTPM NV index `0x01400002`, then execute this command.
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Request attestation report with user-provided data
+//! snpguest report report.bin request-file.bin
+//!
+//! # Request attestation report with randomly generated data
+//! snpguest report report.bin request-file.bin --random
+//!
+//! # Get attestation report and request data from vTPM
+//! snpguest report report.bin request-file.bin --platform
+//! ```
+//!
 
 use super::*;
 
@@ -17,7 +86,7 @@ use sev::{
     parser::{ByteParser, Encoder},
 };
 
-// Read a bin-formatted attestation report.
+/// Read and parse a binary-formatted attestation report from a file.
 pub fn read_report(att_report_path: PathBuf) -> Result<AttestationReport, anyhow::Error> {
     let mut attestation_file = fs::File::open(att_report_path)?;
 
@@ -32,42 +101,50 @@ pub fn read_report(att_report_path: PathBuf) -> Result<AttestationReport, anyhow
     Ok(attestation_report)
 }
 
-// Create 64 random bytes of data for attestation report request
+/// Create 64 random bytes of data for an attestation report request.
 pub fn create_random_request() -> [u8; 64] {
     let mut data = [0u8; 64];
     thread_rng().fill_bytes(&mut data);
     data
 }
 
-/// Report command to request an attestation report.
+/// CLI arguments for the `report` subcommand.
+///
+/// Requests an attestation report from the AMD Secure Processor and writes
+/// it to `att_report_path` as raw binary.
 #[derive(Parser)]
 pub struct ReportArgs {
-    /// File to write the attestation report to.
+    /// Path where the attestation report will be stored.
     #[arg(value_name = "att-report-path", required = true)]
     pub att_report_path: PathBuf,
 
-    /// Use random data for attestation report request. Writes data
-    /// to ./random-request-file.txt by default, use --request to specify
-    /// where to write data.
+    /// Generate 64 random bytes of data for the report request. The random
+    /// data will be written to the path specified by `request-file`.
     #[arg(short, long, default_value_t = false, conflicts_with = "platform")]
     pub random: bool,
 
-    /// Specify an integer VMPL level between 0 and 3 that the Guest is running on.
+    /// VMPL (Virtual Machine Privilege Level) value for the report (0-3).
+    /// Must be greater than or equal to the current VMPL. Default is 1.
     #[arg(short, long, default_value = "1", value_name = "vmpl")]
     pub vmpl: Option<u32>,
 
-    /// Provide file with data for attestation-report request. If provided
-    /// with random flag, then the random data will be written in the
-    /// provided path.
+    /// Path to the 64-byte request data file. Without `--random` or
+    /// `--platform`, the first 64 bytes of this file are sent as the
+    /// request data. With `--random`, the generated data is written here.
+    /// With `--platform`, the report data from the vTPM is written here.
     #[arg(value_name = "request-file", required = true)]
     pub request_file: PathBuf,
 
-    /// Expect that the 64-byte report data will already be provided by the platform provider.
+    /// Retrieve the attestation report from the vTPM NV index instead of the
+    /// AMD Secure Processor. Only available on Azure CVMs with SEV-SNP
+    /// isolation (requires the `hyperv` feature).
     #[arg(short, long, conflicts_with = "random")]
     pub platform: bool,
 }
 
 impl ReportArgs {
+    /// Validate argument combinations (e.g., `--random` and `--platform` are mutually exclusive,
+    /// `--platform` requires Hyper-V with SEV-SNP isolation).
     pub fn verify(&self, hyperv: bool) -> Result<()> {
         if self.random && self.platform {
             return Err(anyhow!(
@@ -107,7 +184,11 @@ fn request_hardware_report(
     )?)
 }
 
-// Request attestation report and write it into a file
+/// Request an attestation report and write it to a file.
+///
+/// Depending on the flags, request data is either read from `request_file`,
+/// generated randomly (`--random`), or retrieved from the vTPM (`--platform`).
+/// The resulting attestation report is serialized and written to `att_report_path`.
 pub fn get_report(args: ReportArgs, hv: bool) -> Result<()> {
     args.verify(hv)?;
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,5 +1,92 @@
 // SPDX-License-Identifier: Apache-2.0
-// This file includes subcommands for verifying certificate chains and attestation reports. Submodules `certificate_chain` and `attestation` contain the verification logic for certificates and attestation reports, respectively.
+
+//! Verifies certificate chains and attestation reports.
+//!
+//! This module provide the following subcommands, which performs the verification
+//! of certificate chains and attestation reports.
+//!
+//! - `verify certs` — Verify a certificate chain (ARK → ASK/ASVK → VCEK/VLEK)
+//! - `verify attestation` — Verify an attestation report against a given VCEK/VLEK
+//!   certificate and reference values.
+//!
+//! ## `verify certs`
+//!
+//! ```bash
+//! snpguest verify certs $CERTS_DIR
+//! ```
+//!
+//! This command then verifies that
+//!
+//! - ARK is self-signed
+//! - ASK (or ASVK) is signed by ARK
+//! - VCEK (or VLEK) is signed by ASK (or ASVK)
+//!
+//! An error will be raised if any of the certificates fail verification.
+//!
+//! ### Argument
+//!
+//! | Argument | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$CERTS_DIR` | The directory where the certificates are stored in. | *required* |
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Verify cert chain stored in ./certs
+//! snpguest verify certs ./certs
+//! ```
+//!
+//! ## `verify attestation`
+//!
+//! ```bash
+//! snpguest verify attestation $CERTS_DIR $ATT_REPORT_PATH [OPTIONS]
+//! ```
+//!
+//! Verifies the attestation report contents and signature using a given VCEK/VLEK
+//! certificate and reference values.
+//!
+//! ### Arguments and Options
+//!
+//! | Argument/Option | Description | Default |
+//! | :--      | :--        | :--    |
+//! | `$CERTS_DIR` | The directory where the leaf certificate is stored in. | *required* |
+//! | `$ATT_REPORT_PATH` | The path of the stored attestation report. | *required* |
+//! | `-p, --processor-model $PROCESSOR_MODEL` | The host processor model (`milan`, `genoa`, `bergano`, `sienna`, `turin`). | - |
+//! | `-t, --tcb` | Skip signature check. | - |
+//! | `-s, --signature` | Skip TCB check. | - |
+//! | `-r, --report-data` | Verify that the REPORT_DATA field in the report matches the given 64-byte data (`0x`-prefixed hex string). | - |
+//! | `-m, --measurement` | Verify that the MEASUREMENT field in the report matches the given 48-byte data (`0x`-prefixed hex string). | - |
+//! | `-d, --host-data` | Verify that the MEASUREMENT field in the report matches the given 32-byte data (`0x`-prefixed hex string). | - |
+//!
+//! The user can specify the host processor model using the `--processor-model`
+//! option. If the processor model is not specified, the command attempts to
+//! infer the host processor model from the report contents. Processor model
+//! autodetection follows the same rules and limitations as the `fetch ca` command.
+//!
+//! ### Example
+//!
+//! ```bash
+//! # Verify Attestation (TCB and signature)
+//! snpguest verify attestation ./certs report.bin
+//!
+//! # Verify TCB only
+//! snpguest verify attestation ./certs report.bin --tcb
+//!
+//! # Verify Signature only
+//! snpguest verify attestation ./certs report.bin --signature
+//!
+//! # Verify TCB, Signature and Report Data
+//! snpguest verify attestation ./certs report.bin \
+//!   --report-data 0x5482c1ffe29145d47cf678f7681e3b64a89909d6cf8ec0104cfacb0b0418f005f564ad14f5c1381c99b74903a780ea340e887c9b445e9c760bf0b74115b26d45
+//!
+//! # Verify TCB, Signature and Measurement
+//! snpguest verify attestation ./certs report.bin \
+//!   --measurement 0xf28aac58964258d8ae0b2e88a706fc7afd0bb524f6a291ac3eedeccb73f89d7cfcf2e4fb6045e7d5201e41d1726afa02
+//!
+//! # Verify TCB, Signature and Host Data
+//! snpguest verify attestation ./certs report.bin \
+//!   --host-data 0x7e4a3f9c1b82a056d39f0d44e5c8a7b1f02394de6b58ac0d7e3c11af0042bd59
+//! ```
 
 use super::*;
 
@@ -18,15 +105,17 @@ use sev::parser::ByteParser;
 
 use hex::FromHex;
 
+/// Subcommands for verifying certificate chains and attestation reports.
 #[derive(Subcommand)]
 pub enum VerifyCmd {
-    /// Verify the certificate chain.
+    /// Verify the certificate chain (ARK self-signed, ASK/ASVK signed by ARK, VCEK/VLEK signed by ASK/ASVK).
     Certs(certificate_chain::Args),
 
-    /// Verify the attestation report.
+    /// Verify the attestation report contents and signature.
     Attestation(attestation::Args),
 }
 
+/// Dispatch to the appropriate verify subcommand handler.
 pub fn cmd(cmd: VerifyCmd, quiet: bool) -> Result<()> {
     match cmd {
         VerifyCmd::Certs(args) => certificate_chain::validate_cc(args, quiet),
@@ -34,7 +123,7 @@ pub fn cmd(cmd: VerifyCmd, quiet: bool) -> Result<()> {
     }
 }
 
-// Find a certificate in specified directory according to its extension
+/// Find a certificate file in the given directory by name, trying `.pem` then `.der` extensions.
 pub fn find_cert_in_dir(dir: &Path, cert: &str) -> Result<PathBuf, anyhow::Error> {
     if dir.join(format!("{cert}.pem")).exists() {
         Ok(dir.join(format!("{cert}.pem")))
@@ -50,14 +139,16 @@ mod certificate_chain {
 
     use super::*;
 
+    /// CLI arguments for `verify certs`.
     #[derive(Parser)]
     pub struct Args {
-        /// Path to directory containing certificate chain."
+        /// Path to directory containing the certificate chain (ARK, ASK/ASVK, VCEK/VLEK).
         #[arg(value_name = "certs-dir", required = true)]
         pub certs_dir: PathBuf,
     }
 
-    // Function to validate certificate chain
+    /// Validate the certificate chain: ARK is self-signed, ASK/ASVK is signed by ARK,
+    /// and VCEK/VLEK is signed by ASK/ASVK.
     pub fn validate_cc(args: Args, quiet: bool) -> Result<()> {
         let ark_path = find_cert_in_dir(&args.certs_dir, "ark")?;
         let (mut vek_type, mut sign_type): (&str, &str) = ("vcek", "ask");
@@ -159,6 +250,9 @@ mod attestation {
         firmware::{guest::AttestationReport, host::CertType},
     };
 
+    /// X.509 OID extensions embedded in the VCEK/VLEK certificate by AMD.
+    /// These are compared against values in the attestation report during
+    /// TCB verification.
     enum SnpOid {
         BootLoader,
         Tee,
@@ -168,7 +262,6 @@ mod attestation {
         Fmc,
     }
 
-    // OID extensions for the VCEK, will be used to verify attestation report
     impl SnpOid {
         fn oid(&self) -> Oid<'static> {
             match self {
@@ -182,41 +275,52 @@ mod attestation {
         }
     }
 
+    /// CLI arguments for `verify attestation`.
+    ///
+    /// By default, both TCB and signature verification are performed.
+    /// Use `-t` to skip signature verification (run only TCB check),
+    /// or `-s` to skip TCB verification (run only signature check).
+    /// Optional report field verification can be requested for
+    /// measurement, host_data, and report_data.
     #[derive(Parser)]
     pub struct Args {
-        /// Path to directory containing VCEK.
+        /// Path to directory containing the VCEK or VLEK certificate.
         #[arg(value_name = "certs-dir", required = true)]
         pub certs_dir: PathBuf,
 
-        /// Path to attestation report to use for validation.
+        /// Path to the attestation report to verify.
         #[arg(value_name = "att-report-path", required = true)]
         pub att_report_path: PathBuf,
 
-        /// Specify the processor model to verify the attestation report.
+        /// Host processor model. If not specified, auto-detected from the report.
         #[arg(short, long, value_name = "processor-model", ignore_case = true)]
         pub processor_model: Option<ProcType>,
 
-        /// Run the TCB Verification Exclusively.
+        /// Verify TCB only (skip signature verification). Conflicts with `--signature`.
         #[arg(short, long, conflicts_with = "signature")]
         pub tcb: bool,
 
-        /// Run the Signature Verification Exclusively.
+        /// Verify signature only (skip TCB verification). Conflicts with `--tcb`.
         #[arg(short, long, conflicts_with = "tcb")]
         pub signature: bool,
 
-        /// Optional measurement string (hex, 48 bytes / 96 chars)
+        /// Expected MEASUREMENT value to verify against the report (0x-prefixed hex string, 48 bytes / 96 hex chars).
         #[arg(short, long, value_name = "measurement")]
         pub measurement: Option<String>,
 
-        /// Optional host_data string (hex, 32 bytes / 64 chars)
+        /// Expected HOST_DATA value to verify against the report (0x-prefixed hex string, 32 bytes / 64 hex chars).
         #[arg(short = 'd', long, value_name = "host_data")]
         pub host_data: Option<String>,
 
-        /// Optional report_data string (hex, 64 bytes / 128 chars)
+        /// Expected REPORT_DATA value to verify against the report (0x-prefixed hex string, 64 bytes / 128 hex chars).
         #[arg(short, long, value_name = "report_data")]
         pub report_data: Option<String>,
     }
 
+    /// Verify the attestation report signature using the VEK (VCEK/VLEK) public key.
+    ///
+    /// Computes a SHA-384 digest over the signed portion of the report (bytes 0x0..0x2A0)
+    /// and verifies the ECDSA signature against the VEK's public key.
     fn verify_attestation_signature(
         vcek: Certificate,
         att_report: AttestationReport,
@@ -255,7 +359,10 @@ mod attestation {
         Ok(())
     }
 
-    // Check the cert extension byte to value
+    /// Compare an X.509 extension value against an expected byte slice.
+    ///
+    /// Handles three encoding formats: ASN.1 integer (type 0x2),
+    /// ASN.1 octet string (type 0x4), and legacy raw byte format.
     fn check_cert_bytes(ext: &X509Extension, val: &[u8]) -> bool {
         match ext.value[0] {
             // Integer
@@ -292,6 +399,7 @@ mod attestation {
         }
     }
 
+    /// Extract the certificate type from the X.509 Subject Common Name field.
     fn parse_common_name(field: &X509Name<'_>) -> Result<CertType> {
         if let Some(val) = field
             .iter_common_name()
@@ -313,6 +421,11 @@ mod attestation {
         }
     }
 
+    /// Verify that REPORTED_TCB fields in the attestation report match the
+    /// corresponding OID extension values in the VEK certificate.
+    ///
+    /// Checks: bootloader, TEE, SNP, microcode, CHIP_ID (VCEK only),
+    /// and FMC (Turin only).
     fn verify_attestation_tcb(
         vcek: Certificate,
         att_report: AttestationReport,
@@ -423,6 +536,13 @@ mod attestation {
         Ok(())
     }
 
+    /// Main entry point for attestation report verification.
+    ///
+    /// By default, runs both TCB and signature checks. When `--tcb` is set,
+    /// only TCB verification runs (signature check is skipped). When `--signature`
+    /// is set, only signature verification runs (TCB check is skipped).
+    /// If optional reference values are provided (`--measurement`, `--host-data`,
+    /// `--report-data`), those report fields are verified as well.
     pub fn verify_attestation(args: Args, quiet: bool) -> Result<()> {
         // Get attestation report
         let att_report = if !args.att_report_path.exists() {
@@ -469,8 +589,15 @@ mod attestation {
         Ok(())
     }
 
+    /// Decode an input string as a byte vector.
+    ///
+    /// If the input starts with `0x`, it is treated as a hex-encoded string.
+    /// Otherwise, the raw UTF-8 bytes of the input are used.
+    ///
+    /// **Note**: Despite the name, the non-hex path converts the string to
+    /// raw UTF-8 bytes rather than parsing it as a decimal number. See
+    /// <https://github.com/virtee/snpguest/issues/135> for details.
     fn decode_hex_or_decimal(input: &str) -> Result<Vec<u8>> {
-        // Look for "0x" at beginning. If it exists, treat as a hex.
         if let Some(hex_str) = input.strip_prefix("0x") {
             Ok(Vec::from_hex(hex_str)?)
         } else {
@@ -478,6 +605,7 @@ mod attestation {
         }
     }
 
+    /// Verify that a report field matches the user-provided reference value.
     fn verify_field(
         field_name: &str,
         expected: &[u8],
@@ -511,6 +639,8 @@ mod attestation {
         Ok(())
     }
 
+    /// Verify optional report fields (measurement, host_data, report_data)
+    /// against user-provided reference values.
     fn verify_report_fields(
         args: &Args,
         att_report: &AttestationReport,


### PR DESCRIPTION
This PR replaces #139.

- Add comprehensive module-level (`//!`) and item-level (`///`) Rustdoc comments across all source files, so `cargo doc` produces a complete API reference and the crate-level documentation can drive a `cargo rdme`-generated `README.md`.
- Regenerate `README.md` from `src/main.rs`'s crate-level doc via `cargo rdme`. The handwritten sections (overview, basic usage, subcommand table, build/install instructions, reporting bugs) now live as the crate-level doc, keeping `cargo doc` output and the rendered README in sync.
- Add a `Rustdoc` CI workflow (`.github/workflows/docs.yml`) that runs on push and pull request:
  - `cargo rdme --check`: fails if `README.md` differs from the crate-level doc.
  - `cargo doc --no-deps --all-features`: fails on broken intra-doc links or other doc-build errors.

### Build

```bash
# cargo install cargo-rdme
cargo rdme
cargo doc --all-features --no-deps
```

### Note

I have left the Asciidoc files as they were. The changes to the adoc files from the preceding PR are not included in this PR.