### PR TITLE
add ID-block and author-key digest verification flags

### DIFF
--- a/src/preattestation.rs
+++ b/src/preattestation.rs
@@ -421,8 +421,7 @@ mod keydigest {
         }
 
         if !quiet {
-            println!("Key Digest:");
-            println!("{}", key_digest_string);
+            println!("0x{}", key_digest_string);
         }
         Ok(())
     }

--- a/src/preattestation.rs
+++ b/src/preattestation.rs
@@ -55,7 +55,8 @@ mod measurement {
 
         /// Type of guest vcpu (EPYC, EPYC-v1, EPYC-v2, EPYC-IBPB, EPYC-v3, EPYC-v4,
         /// EPYC-Rome, EPYC-Rome-v1, EPYC-Rome-v2, EPYC-Rome-v3, EPYC-Milan, EPYC-
-        /// Milan-v1, EPYC-Milan-v2, EPYC-Genoa, EPYC-Genoa-v1)
+        /// Milan-v1, EPYC-Milan-v2, EPYC-Genoa, EPYC-Genoa-v1, EPYC-Turin,
+        /// EPYC-Turin-v1, EPYC-Turin-v2)
         #[arg(long, value_name = "vcpu-type", 
             conflicts_with_all = ["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"], 
             required_unless_present_any(["vcpu_sig", "vcpu_family", "vcpu_model", "vcpu_stepping"],

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -215,6 +215,14 @@ mod attestation {
         /// Optional report_data string (hex, 64 bytes / 128 chars)
         #[arg(short, long, value_name = "report_data")]
         pub report_data: Option<String>,
+
+        /// Optional id_key_digest string (hex, 48 bytes / 96 chars)
+        #[arg(long, value_name = "id_key_digest")]
+        pub id_key_digest: Option<String>,
+
+        /// Optional author_key_digest string (hex, 48 bytes / 96 chars)
+        #[arg(long, value_name = "author_key_digest")]
+        pub author_key_digest: Option<String>,
     }
 
     fn verify_attestation_signature(
@@ -462,7 +470,12 @@ mod attestation {
         }
 
         // Verify optional fields if provided
-        if args.measurement.is_some() || args.host_data.is_some() || args.report_data.is_some() {
+        if args.measurement.is_some()
+            || args.host_data.is_some()
+            || args.report_data.is_some()
+            || args.id_key_digest.is_some()
+            || args.author_key_digest.is_some()
+        {
             verify_report_fields(&args, &att_report, quiet)?;
         }
 
@@ -540,6 +553,24 @@ mod attestation {
                 att_report.report_data.as_slice(),
                 report,
                 64,
+                quiet,
+            )?;
+        }
+        if let Some(idk) = &args.id_key_digest {
+            verify_field(
+                "ID Key Digest",
+                att_report.id_key_digest.as_slice(),
+                idk,
+                48,
+                quiet,
+            )?;
+        }
+        if let Some(ak) = &args.author_key_digest {
+            verify_field(
+                "Author Key Digest",
+                att_report.author_key_digest.as_slice(),
+                ak,
+                48,
                 quiet,
             )?;
         }


### PR DESCRIPTION
The launch measurement covers VM contents (firmware, kernel, initrd, cmdline, vCPU state) but does not bind the launch to a specific signing authority - anyone with the same image inputs can compute the same launch digest and run a VM under their own ID-block key. To verify that a report came from a launch authorized by a trusted party, the report's `ID_KEY_DIGEST (offset 0xE0)` and `AUTHOR_KEY_DIGEST (offset 0x110)` need to be checked against expected values.

Until now this required extracting the digests with dd and comparing manually. This change exposes them as one-shot verify flags, mirroring the existing `--measurement` flag:

```
        verify attestation ./certs ./report.bin
            --id-key-digest     <hex>
            --author-key-digest <hex>
```

To make the digests easy to capture from the shell, change 'generate key-digest' stdout from a two-line "Key Digest:\n<hex>" to a single-line "0x<hex>" - consistent with `generate measurement` . The --key-digest-file output is unchanged (raw hex, no 0x prefix).

Full one-shot verification flow (Turin example):

```
        EXPECTED_MEAS=$(snpguest generate measurement                \
            --ovmf firmware-code.fd                                  \
            --kernel vmlinuz --initrd initrd.img                     \
            --append "$(cat kernel-params.txt)"                      \
            --vcpus 4 --vcpu-type EPYC-Turin)

        EXPECTED_IDK=$(snpguest generate key-digest id-block-key.pem)
        EXPECTED_AK=$(snpguest generate key-digest id-auth-key.pem)

        snpguest verify attestation ./certs ./report.bin             \
            --measurement       "$EXPECTED_MEAS"                     \
            --id-key-digest     "$EXPECTED_IDK"                      \
            --author-key-digest "$EXPECTED_AK"
```

That single call performs TCB-vs-VCEK matching, VEK signature verification, launch-measurement comparison, ID-key digest comparison, and author-key digest comparison.
