### PR TITLE
Update sev to v8.0.0 for snpguest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -1258,15 +1258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "7.1.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
+checksum = "5031e00ad6d00d24f6b9990a181fdc8dc6e6222ba9ef657f2d8cf29e4c36b948"
 dependencies = [
  "base64 0.22.1",
  "bitfield 0.19.2",
@@ -1509,7 +1500,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "openssl",
- "rdrand",
  "static_assertions",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hyperv = ["tss-esapi"]
 clap = { version = "4.5", features = [ "derive" ] }
 env_logger = "0.10.0"
 anyhow = "1.0.69"
-sev = { version = "=7.1.0", default-features = false, features = ['openssl','snp']}
+sev = { version = "=8.0.0", default-features = false, features = ['openssl','snp']}
 serde = { version = "1.0", features = ["derive"] }
 bincode = "^1.2.1"
 openssl = { version = "^0.10", features = ["vendored"]}


### PR DESCRIPTION
## Overview

Update sev to v8.0.0, which contains the following changes: [link](https://github.com/virtee/sev/compare/5ccc9afa70062177a9ccc3ad49703fa16f4e87ed%E2%80%A676535be354648a3e4adf00631fdf4941ab51fb88)

## Testing

Ran `cargo build` successfully